### PR TITLE
fixed date of incorporation based navigation and back links

### DIFF
--- a/app/controllers/CommercialSaleController.scala
+++ b/app/controllers/CommercialSaleController.scala
@@ -47,8 +47,8 @@ trait CommercialSaleController extends FrontendController with ValidActiveSessio
     def routeRequest(date: Option[DateOfIncorporationModel]): Future[Result] = {
       date match {
         case Some(data) if Validation.dateAfterIncorporationRule(data.day.get, data.month.get, data.year.get) =>
-          Future.successful(Redirect(routes.IsKnowledgeIntensiveController.show))
-        case Some(_) => Future.successful(Redirect(routes.SubsidiariesController.show))
+          Future.successful(Redirect(routes.SubsidiariesController.show))
+        case Some(_) => Future.successful(Redirect(routes.IsKnowledgeIntensiveController.show))
         case None => Future.successful(Redirect(routes.DateOfIncorporationController.show))
       }
     }

--- a/app/controllers/SubsidiariesContoller.scala
+++ b/app/controllers/SubsidiariesContoller.scala
@@ -82,8 +82,8 @@ trait SubsidiariesController extends FrontendController with ValidActiveSession 
     def routeRequest(date: Option[DateOfIncorporationModel]): String = {
       date match {
         case Some(data) if Validation.dateAfterIncorporationRule(data.day.get, data.month.get, data.year.get) =>
-          routes.IsKnowledgeIntensiveController.show.toString
-        case Some(_) => routes.CommercialSaleController.show.toString
+          routes.CommercialSaleController.show.toString
+        case Some(_) => routes.IsKnowledgeIntensiveController.show.toString
         case None => routes.DateOfIncorporationController.show.toString
       }
     }

--- a/test/controllers/CommercialSaleControllerSpec.scala
+++ b/test/controllers/CommercialSaleControllerSpec.scala
@@ -139,7 +139,7 @@ class CommercialSaleControllerSpec extends UnitSpec with MockitoSugar with Befor
       submitWithSession(request)(
         result => {
           status(result) shouldBe SEE_OTHER
-          redirectLocation(result) shouldBe Some("/investment-tax-relief/subsidiaries")
+          redirectLocation(result) shouldBe Some("/investment-tax-relief/is-knowledge-intensive")
         }
       )
     }
@@ -157,7 +157,7 @@ class CommercialSaleControllerSpec extends UnitSpec with MockitoSugar with Befor
       submitWithSession(request)(
         result => {
           status(result) shouldBe SEE_OTHER
-          redirectLocation(result) shouldBe Some("/investment-tax-relief/subsidiaries")
+          redirectLocation(result) shouldBe Some("/investment-tax-relief/is-knowledge-intensive")
         }
       )
     }
@@ -175,7 +175,7 @@ class CommercialSaleControllerSpec extends UnitSpec with MockitoSugar with Befor
       submitWithSession(request)(
         result => {
           status(result) shouldBe SEE_OTHER
-          redirectLocation(result) shouldBe Some("/investment-tax-relief/is-knowledge-intensive")
+          redirectLocation(result) shouldBe Some("/investment-tax-relief/subsidiaries")
         }
       )
     }
@@ -194,7 +194,7 @@ class CommercialSaleControllerSpec extends UnitSpec with MockitoSugar with Befor
       submitWithSession(request)(
         result => {
           status(result) shouldBe SEE_OTHER
-          redirectLocation(result) shouldBe Some("/investment-tax-relief/subsidiaries")
+          redirectLocation(result) shouldBe Some("/investment-tax-relief/is-knowledge-intensive")
         }
       )
     }
@@ -212,7 +212,7 @@ class CommercialSaleControllerSpec extends UnitSpec with MockitoSugar with Befor
       submitWithSession(request)(
         result => {
           status(result) shouldBe SEE_OTHER
-          redirectLocation(result) shouldBe Some("/investment-tax-relief/subsidiaries")
+          redirectLocation(result) shouldBe Some("/investment-tax-relief/is-knowledge-intensive")
         }
       )
     }
@@ -230,7 +230,7 @@ class CommercialSaleControllerSpec extends UnitSpec with MockitoSugar with Befor
       submitWithSession(request)(
         result => {
           status(result) shouldBe SEE_OTHER
-          redirectLocation(result) shouldBe Some("/investment-tax-relief/is-knowledge-intensive")
+          redirectLocation(result) shouldBe Some("/investment-tax-relief/subsidiaries")
         }
       )
     }

--- a/test/views/SubsidiariesSpec.scala
+++ b/test/views/SubsidiariesSpec.scala
@@ -107,7 +107,7 @@ class SubsidiariesSpec extends UnitSpec with WithFakeApplication with MockitoSug
       }
 
       // Back link should change based on the value of date of incorporation retrieved from keystore
-      document.body.getElementById("back-link").attr("href") shouldEqual routes.CommercialSaleController.show.toString()
+      document.body.getElementById("back-link").attr("href") shouldEqual routes.IsKnowledgeIntensiveController.show.toString()
       document.title() shouldBe Messages("page.companyDetails.Subsidiaries.title")
       document.getElementById("main-heading").text() shouldBe Messages("page.companyDetails.Subsidiaries.heading")
       document.select("#subsidiaries-yes").size() shouldBe 1
@@ -133,7 +133,7 @@ class SubsidiariesSpec extends UnitSpec with WithFakeApplication with MockitoSug
       }
 
       // Back link should change based on the value of date of incorporation retrieved from keystore
-      document.body.getElementById("back-link").attr("href") shouldEqual routes.CommercialSaleController.show.toString()
+      document.body.getElementById("back-link").attr("href") shouldEqual routes.IsKnowledgeIntensiveController.show.toString()
       document.title() shouldBe Messages("page.companyDetails.Subsidiaries.title")
       document.getElementById("main-heading").text() shouldBe Messages("page.companyDetails.Subsidiaries.heading")
       document.select("#subsidiaries-yes").size() shouldBe 1
@@ -159,7 +159,7 @@ class SubsidiariesSpec extends UnitSpec with WithFakeApplication with MockitoSug
       }
 
       // Back link should change based on the value of date of incorporation retrieved from keystore
-      document.body.getElementById("back-link").attr("href") shouldEqual routes.IsKnowledgeIntensiveController.show.toString()
+      document.body.getElementById("back-link").attr("href") shouldEqual routes.CommercialSaleController.show.toString()
       document.title() shouldBe Messages("page.companyDetails.Subsidiaries.title")
       document.getElementById("main-heading").text() shouldBe Messages("page.companyDetails.Subsidiaries.heading")
       document.select("#subsidiaries-yes").size() shouldBe 1
@@ -212,7 +212,7 @@ class SubsidiariesSpec extends UnitSpec with WithFakeApplication with MockitoSug
       }
 
       // Back link should change based on the value of date of incorporation retrieved from keystore
-      document.body.getElementById("back-link").attr("href") shouldEqual routes.CommercialSaleController.show.toString()
+      document.body.getElementById("back-link").attr("href") shouldEqual routes.IsKnowledgeIntensiveController.show.toString()
       document.title() shouldBe Messages("page.companyDetails.Subsidiaries.title")
       document.getElementById("main-heading").text() shouldBe Messages("page.companyDetails.Subsidiaries.heading")
       document.select("#subsidiaries-yes").size() shouldBe 1
@@ -238,7 +238,7 @@ class SubsidiariesSpec extends UnitSpec with WithFakeApplication with MockitoSug
       }
 
       // Back link should change based on the value of date of incorporation retrieved from keystore
-      document.body.getElementById("back-link").attr("href") shouldEqual routes.CommercialSaleController.show.toString()
+      document.body.getElementById("back-link").attr("href") shouldEqual routes.IsKnowledgeIntensiveController.show.toString()
       document.title() shouldBe Messages("page.companyDetails.Subsidiaries.title")
       document.getElementById("main-heading").text() shouldBe Messages("page.companyDetails.Subsidiaries.heading")
       document.select("#subsidiaries-yes").size() shouldBe 1
@@ -264,7 +264,7 @@ class SubsidiariesSpec extends UnitSpec with WithFakeApplication with MockitoSug
       }
 
       // Back link should change based on the value of date of incorporation retrieved from keystore
-      document.body.getElementById("back-link").attr("href") shouldEqual routes.IsKnowledgeIntensiveController.show.toString()
+      document.body.getElementById("back-link").attr("href") shouldEqual routes.CommercialSaleController.show.toString()
       document.title() shouldBe Messages("page.companyDetails.Subsidiaries.title")
       document.getElementById("main-heading").text() shouldBe Messages("page.companyDetails.Subsidiaries.heading")
       document.select("#subsidiaries-yes").size() shouldBe 1
@@ -316,7 +316,7 @@ class SubsidiariesSpec extends UnitSpec with WithFakeApplication with MockitoSug
       }
 
       // Back link should change based on the value of date of incorporation retrieved from keystore
-      document.body.getElementById("back-link").attr("href") shouldEqual routes.IsKnowledgeIntensiveController.show.toString()
+      document.body.getElementById("back-link").attr("href") shouldEqual routes.CommercialSaleController.show.toString()
       document.title() shouldBe Messages("page.companyDetails.Subsidiaries.title")
       document.getElementById("main-heading").text() shouldBe Messages("page.companyDetails.Subsidiaries.heading")
       document.select("#subsidiaries-yes").size() shouldBe 1
@@ -341,7 +341,7 @@ class SubsidiariesSpec extends UnitSpec with WithFakeApplication with MockitoSug
       // Make sure we have the expected error summary displayed and correct backv link rendered on error
       document.getElementById("error-summary-display").hasClass("error-summary--show")
       document.title() shouldBe Messages("page.companyDetails.Subsidiaries.title")
-      document.body.getElementById("back-link").attr("href") shouldEqual routes.CommercialSaleController.show.toString()
+      document.body.getElementById("back-link").attr("href") shouldEqual routes.IsKnowledgeIntensiveController.show.toString()
     }
 
     "Verify that Subsidiaries page contains show the error summary when an invalid model (no radio button selection) +" +
@@ -358,7 +358,7 @@ class SubsidiariesSpec extends UnitSpec with WithFakeApplication with MockitoSug
       // Make sure we have the expected error summary displayed and correct backv link rendered on error
       document.getElementById("error-summary-display").hasClass("error-summary--show")
       document.title() shouldBe Messages("page.companyDetails.Subsidiaries.title")
-      document.body.getElementById("back-link").attr("href") shouldEqual routes.CommercialSaleController.show.toString()
+      document.body.getElementById("back-link").attr("href") shouldEqual routes.IsKnowledgeIntensiveController.show.toString()
     }
 
     "Verify that Subsidiaries page contains show the error summary when an invalid model (no radio button selection) +" +
@@ -375,7 +375,7 @@ class SubsidiariesSpec extends UnitSpec with WithFakeApplication with MockitoSug
       // Make sure we have the expected error summary displayed and correct backv link rendered on error
       document.getElementById("error-summary-display").hasClass("error-summary--show")
       document.title() shouldBe Messages("page.companyDetails.Subsidiaries.title")
-      document.body.getElementById("back-link").attr("href") shouldEqual routes.IsKnowledgeIntensiveController.show.toString()
+      document.body.getElementById("back-link").attr("href") shouldEqual routes.CommercialSaleController.show.toString()
     }
 
     "Verify that Subsidiaries page contains show the error summary when an invalid model (no radio button selection) +" +


### PR DESCRIPTION
Updated code so that if it is less than 3 years from date of incorporation (DOI) then for:

Commercial sale page:
Navigation is to the Subsidiaries page (if less than 3 years for DOI) otherwise to Knowledge intensive (KI) page. NB. if no DOI entered previously then will navigate to DOI page.

Subsidiaries page:
Back link navigates to commercial Sale page if DOI is less than 3 years from today otherwise to Knowledge Intensive page.
