### PR TITLE
TAVC-1298 - Updated Operating Costs field validation.

### DIFF
--- a/app/forms/OperatingCostsForm.scala
+++ b/app/forms/OperatingCostsForm.scala
@@ -19,13 +19,26 @@ package forms
 import models.OperatingCostsModel
 import play.api.data.Form
 import play.api.data.Forms._
+import play.api.i18n.Messages
+import utils.Transfomers._
+import utils.Validation._
 
 object OperatingCostsForm {
+
+  val maxAllowableAmount: Int = 999999999
+  val minAllowableAmount: Int = 1
+
+  //    "operatingCosts1stYear" -> text
+  //        .verifying(Messages("validation.common.error.fieldRequired"), mandatoryCheck)
+  //        .verifying(Messages("page.companyDetails.OperatingCosts.amount.invalidAmount"), integerCheck)
+  //        .verifying(Messages("page.companyDetails.OperatingCosts.amount.OutOfRange"), minIntCheckString(minAllowableAmount))
+  //        .verifying(Messages("page.companyDetails.OperatingCosts.amount.OutOfRange"), maxIntCheckString(maxAllowableAmount)),
+
   val operatingCostsForm = Form(
     mapping(
-      "operatingCosts1stYear" -> utils.Validation.mandatoryMaxTenNumberValidation("page.companyDetails.OperatingCosts.error.field.one"),
-      "operatingCosts2ndYear" -> utils.Validation.mandatoryMaxTenNumberValidation("page.companyDetails.OperatingCosts.error.field.two"),
-      "operatingCosts3rdYear" -> utils.Validation.mandatoryMaxTenNumberValidation("page.companyDetails.OperatingCosts.error.field.three"),
+      "operatingCosts1stYear" -> utils.Validation.mandatoryMaxTenNumberNonZeroValidation("page.companyDetails.OperatingCosts.error.field.one"),
+      "operatingCosts2ndYear" -> utils.Validation.mandatoryMaxTenNumberNonZeroValidation("page.companyDetails.OperatingCosts.error.field.two"),
+      "operatingCosts3rdYear" -> utils.Validation.mandatoryMaxTenNumberNonZeroValidation("page.companyDetails.OperatingCosts.error.field.three"),
       "rAndDCosts1stYear" -> utils.Validation.mandatoryMaxTenNumberValidation("page.companyDetails.OperatingCosts.error.field.four"),
       "rAndDCosts2ndYear" -> utils.Validation.mandatoryMaxTenNumberValidation("page.companyDetails.OperatingCosts.error.field.five"),
       "rAndDCosts3rdYear" -> utils.Validation.mandatoryMaxTenNumberValidation("page.companyDetails.OperatingCosts.error.field.six")

--- a/app/utils/Transfomers.scala
+++ b/app/utils/Transfomers.scala
@@ -47,4 +47,9 @@ object Transfomers {
   val integerToFormattedNumber: Int => String = {
     (value) => NumberFormat.getNumberInstance.format(value)
   }
+
+  val integerToString: Int => String = (input) => Try(input.toString) match {
+    case Success(value) => value
+    case Failure(_) => ""
+  }
 }

--- a/app/utils/Validation.scala
+++ b/app/utils/Validation.scala
@@ -161,6 +161,20 @@ object Validation {
     text.verifying(numCharCheckConstraint)
   }
 
+  def mandatoryMaxTenNumberNonZeroValidation(message: String) : Mapping[String] = {
+    val validNum = """^[1-9][0-9]{0,8}$""".r
+    val numCharCheckConstraint: Constraint[String] =
+      Constraint("contraints.mandatoryNumberCheck")({
+        text =>
+          val error = text match {
+            case validNum() => Nil
+            case _ => Seq(ValidationError(Messages(message)))
+          }
+          if (error.isEmpty) Valid else Invalid(error)
+      })
+    text.verifying(numCharCheckConstraint)
+  }
+
   def optionalAddressLineCheck: Mapping[String] = {
     val validAddressLine = """^$|[a-zA-Z0-9,.\(\)/&'"\-]{1}[a-zA-Z0-9, .\(\)/&'"\-]{0,26}""".r
     val addresssLineCheckConstraint: Constraint[String] =
@@ -314,6 +328,17 @@ object Validation {
 
   def maxIntCheck (maxInteger: Int) : Int => Boolean = (input) => input <= maxInteger
   def minIntCheck (minInteger: Int) : Int => Boolean = (input) => input >= minInteger
+
+  def maxIntCheckString (maxInteger: Int) : String => Boolean = (input) => Try(input.trim.toInt) match {
+    case Success(value) => value <= maxInteger
+    case Failure(_) => false
+  }
+
+  def minIntCheckString (minInteger: Int) : String => Boolean = (input) => Try(input.trim.toInt) match {
+    case Success(value) => value >= minInteger
+    case Failure(_) => false
+  }
+
 
   val yesNoCheck: String =>  Boolean = {
     case Constants.StandardRadioButtonYesValue => true

--- a/conf/messages
+++ b/conf/messages
@@ -242,9 +242,12 @@ page.companyDetails.OperatingCosts.col.heading.three = Research and Development 
 page.companyDetails.OperatingCosts.row.heading.one = 2015 - 2016
 page.companyDetails.OperatingCosts.row.heading.two = 2014 - 2015
 page.companyDetails.OperatingCosts.row.heading.three = 2013 - 2014
-page.companyDetails.OperatingCosts.error.field.one = Operating Costs 1st Year must be up to 9 numbers.
-page.companyDetails.OperatingCosts.error.field.two = Operating Costs 2nd Year must be up to 9 numbers.
-page.companyDetails.OperatingCosts.error.field.three = Operating Costs 3rd Year must be up to 9 numbers.
+
+page.companyDetails.OperatingCosts.amount.invalidAmount = Enter an amount in the correct format e.g. 10000
+page.companyDetails.OperatingCosts.amount.OutOfRange = Enter an amount between 1 and 999999999
+page.companyDetails.OperatingCosts.error.field.one = Operating Costs 1st Year must be greater than 0 and must be up to 9 numbers.
+page.companyDetails.OperatingCosts.error.field.two = Operating Costs 2nd Year must be greater than 0 and must be up to 9 numbers.
+page.companyDetails.OperatingCosts.error.field.three = Operating Costs 3rd Year must be greater than 0 and must be up to 9 numbers.
 page.companyDetails.OperatingCosts.error.field.four = Research and Development Costs 1st Year must be up to 9 numbers.
 page.companyDetails.OperatingCosts.error.field.five = Research and Development Costs 2nd Year must be up to 9 numbers.
 page.companyDetails.OperatingCosts.error.field.six = Research and Development Costs 3rd Year must be up to 9 numbers.


### PR DESCRIPTION
Added validation to only allow a number that doesn't start with 0