### PR TITLE
TAVC-1408: Added the Enrolment check to the controller action predicate

### DIFF
--- a/app/auth/Enrolment.scala
+++ b/app/auth/Enrolment.scala
@@ -16,16 +16,10 @@
 
 package auth
 
-import config.AppConfig
+import play.api.libs.json.Json
 
-object MockConfig extends AppConfig {
-  override val assetsPrefix: String = ""
-  override val analyticsToken: String = ""
-  override val analyticsHost: String = ""
-  override val reportAProblemPartialUrl: String = ""
-  override val reportAProblemNonJSUrl: String = ""
-  override val notAuthorisedRedirectUrl: String = "/investment-tax-relief/not-authorised"
-  override val ggSignInUrl: String = "/gg/sign-in"
-  override val introductionUrl: String = "http://localhost:9635/investment-tax-relief/your-company-need"
-  override val subscriptionUrl: String = "/investment-tax-relief-subscription/"
+case class Enrolment(key: String, identifiers: Seq[Identifier], state: String)
+
+object Enrolment {
+  implicit val formats = Json.format[Enrolment]
 }

--- a/app/auth/EnrolmentResult.scala
+++ b/app/auth/EnrolmentResult.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package auth
+
+sealed trait EnrolmentResult {}
+case object Enrolled extends EnrolmentResult
+case object NotEnrolled extends EnrolmentResult

--- a/app/auth/Identifier.scala
+++ b/app/auth/Identifier.scala
@@ -16,16 +16,10 @@
 
 package auth
 
-import config.AppConfig
+import play.api.libs.json.Json
 
-object MockConfig extends AppConfig {
-  override val assetsPrefix: String = ""
-  override val analyticsToken: String = ""
-  override val analyticsHost: String = ""
-  override val reportAProblemPartialUrl: String = ""
-  override val reportAProblemNonJSUrl: String = ""
-  override val notAuthorisedRedirectUrl: String = "/investment-tax-relief/not-authorised"
-  override val ggSignInUrl: String = "/gg/sign-in"
-  override val introductionUrl: String = "http://localhost:9635/investment-tax-relief/your-company-need"
-  override val subscriptionUrl: String = "/investment-tax-relief-subscription/"
+case class Identifier(key: String, value: String)
+
+object Identifier {
+  implicit val formats = Json.format[Identifier]
 }

--- a/app/config/frontendAppConfig.scala
+++ b/app/config/frontendAppConfig.scala
@@ -28,6 +28,7 @@ trait AppConfig {
   val notAuthorisedRedirectUrl: String
   val ggSignInUrl: String
   val introductionUrl: String
+  val subscriptionUrl: String
 }
 
 object FrontendAppConfig extends AppConfig with ServicesConfig {
@@ -42,8 +43,8 @@ object FrontendAppConfig extends AppConfig with ServicesConfig {
   override lazy val analyticsHost = loadConfig(s"google-analytics.host")
   override lazy val reportAProblemPartialUrl = s"$contactHost/contact/problem_reports_ajax?service=$contactFormServiceIdentifier"
   override lazy val reportAProblemNonJSUrl = s"$contactHost/contact/problem_reports_nonjs?service=$contactFormServiceIdentifier"
-
   override lazy val notAuthorisedRedirectUrl = configuration.getString("not-authorised-callback.url").getOrElse("")
   override lazy val ggSignInUrl: String = configuration.getString(s"government-gateway-sign-in.host").getOrElse("")
   override lazy val introductionUrl: String = configuration.getString(s"introduction.url").getOrElse("")
+  override lazy val subscriptionUrl: String = loadConfig("investment-tax-relief-subscription.url")
 }

--- a/app/connectors/EnrolmentConnector.scala
+++ b/app/connectors/EnrolmentConnector.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import config.WSHttp
+import play.api.http.Status._
+import uk.gov.hmrc.play.http.HeaderCarrier
+import uk.gov.hmrc.play.config.ServicesConfig
+import uk.gov.hmrc.play.http._
+import auth.Enrolment
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+trait EnrolmentConnector extends ServicesConfig {
+
+  def serviceUrl: String
+  def authorityUri: String
+  def http: HttpGet with HttpPost
+
+  def getTAVCEnrolment(uri: String)(implicit hc: HeaderCarrier): Future[Option[Enrolment]] = {
+    val getUrl = s"$serviceUrl$uri/enrolments"
+    http.GET[HttpResponse](getUrl).map {
+      response =>
+        response.status match {
+          case OK => response.json.as[Seq[Enrolment]].find(_.key == "HMRC-TAVC-ORG")
+          case status => None
+        }
+    }
+  }
+}
+
+object EnrolmentConnector extends EnrolmentConnector {
+  lazy val serviceUrl = baseUrl("auth")
+  val authorityUri = "auth/authority"
+  val http: HttpGet with HttpPost = WSHttp
+}

--- a/app/controllers/AcknowledgementController.scala
+++ b/app/controllers/AcknowledgementController.scala
@@ -17,13 +17,11 @@
 package controllers
 
 
-import auth.AuthorisedForTAVC
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import common.{KeystoreKeys, Constants}
-import connectors.{KeystoreConnector, SubmissionConnector}
-
-import models.{YourCompanyNeedModel, ContactDetailsModel, SubmissionRequest, SubmissionResponse}
-
+import auth.AuthorisedAndEnrolledForTAVC
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import common.{Constants, KeystoreKeys}
+import connectors.{EnrolmentConnector, KeystoreConnector, SubmissionConnector}
+import models.{ContactDetailsModel, SubmissionRequest, SubmissionResponse, YourCompanyNeedModel}
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 
 
@@ -32,14 +30,15 @@ object AcknowledgementController extends AcknowledgementController{
   val submissionConnector: SubmissionConnector = SubmissionConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait AcknowledgementController extends FrontendController with AuthorisedForTAVC{
+trait AcknowledgementController extends FrontendController with AuthorisedAndEnrolledForTAVC{
 
   val keyStoreConnector: KeystoreConnector
   val submissionConnector: SubmissionConnector
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     /** Dummy implementation. Will be replaced by final Submission model**/
 
     def subModel =for {

--- a/app/controllers/CheckAnswersController.scala
+++ b/app/controllers/CheckAnswersController.scala
@@ -16,10 +16,10 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
+import auth.AuthorisedAndEnrolledForTAVC
 import common.KeystoreKeys
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.KeystoreConnector
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import models._
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 import uk.gov.hmrc.play.http.HeaderCarrier
@@ -31,9 +31,10 @@ object CheckAnswersController extends CheckAnswersController{
   val keyStoreConnector: KeystoreConnector = KeystoreConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait CheckAnswersController extends FrontendController with AuthorisedForTAVC {
+trait CheckAnswersController extends FrontendController with AuthorisedAndEnrolledForTAVC {
 
   val keyStoreConnector: KeystoreConnector
 
@@ -68,11 +69,11 @@ trait CheckAnswersController extends FrontendController with AuthorisedForTAVC {
     subsidiariesNinetyOwned,contactDetails,investmentGrowModel)
 
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     checkAnswersModel.flatMap(checkAnswer => Future.successful(Ok(CheckAnswers(checkAnswer))))
   }
 
-  val submit = Authorised.async { implicit  user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     Future.successful(Redirect(routes.AcknowledgementController.show()))
   }
 

--- a/app/controllers/CommercialSaleController.scala
+++ b/app/controllers/CommercialSaleController.scala
@@ -16,9 +16,9 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.KeystoreConnector
+import auth.AuthorisedAndEnrolledForTAVC
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 import play.api.mvc._
 import models.{CommercialSaleModel, KiProcessingModel}
@@ -32,20 +32,21 @@ object CommercialSaleController extends CommercialSaleController {
   val keyStoreConnector: KeystoreConnector = KeystoreConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait CommercialSaleController extends FrontendController with AuthorisedForTAVC {
+trait CommercialSaleController extends FrontendController with AuthorisedAndEnrolledForTAVC {
 
   val keyStoreConnector: KeystoreConnector
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     keyStoreConnector.fetchAndGetFormData[CommercialSaleModel](KeystoreKeys.commercialSale).map {
       case Some(data) => Ok(CommercialSale(commercialSaleForm.fill(data)))
       case None => Ok(CommercialSale(commercialSaleForm))
     }
   }
 
-  val submit = Authorised.async { implicit user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
 
     def routeRequest(kiModel: Option[KiProcessingModel]): Future[Result] = {
       kiModel match {

--- a/app/controllers/ConfirmCorrespondAddressController.scala
+++ b/app/controllers/ConfirmCorrespondAddressController.scala
@@ -16,10 +16,10 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
+import auth.AuthorisedAndEnrolledForTAVC
 import common.{Constants, KeystoreKeys}
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.KeystoreConnector
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import forms.ConfirmCorrespondAddressForm._
 import models.ConfirmCorrespondAddressModel
 import uk.gov.hmrc.play.frontend.controller.FrontendController
@@ -31,20 +31,21 @@ object ConfirmCorrespondAddressController extends ConfirmCorrespondAddressContro
   val keyStoreConnector: KeystoreConnector = KeystoreConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait ConfirmCorrespondAddressController extends FrontendController with AuthorisedForTAVC {
+trait ConfirmCorrespondAddressController extends FrontendController with AuthorisedAndEnrolledForTAVC {
 
   val keyStoreConnector: KeystoreConnector
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     keyStoreConnector.fetchAndGetFormData[ConfirmCorrespondAddressModel](KeystoreKeys.confirmContactAddress).map {
       case Some(data) => Ok(ConfirmCorrespondAddress(confirmCorrespondAddressForm.fill(data)))
       case None => Ok(ConfirmCorrespondAddress(confirmCorrespondAddressForm))
     }
   }
 
-  val submit = Authorised.async { implicit user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     confirmCorrespondAddressForm.bindFromRequest().fold(
       formWithErrors => {
         Future.successful(BadRequest(ConfirmCorrespondAddress(formWithErrors)))

--- a/app/controllers/ContactAddressController.scala
+++ b/app/controllers/ContactAddressController.scala
@@ -16,10 +16,10 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
+import auth.AuthorisedAndEnrolledForTAVC
 import common.KeystoreKeys
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.KeystoreConnector
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import forms.ContactAddressForm._
 import models.ContactAddressModel
 import play.api.mvc._
@@ -33,20 +33,21 @@ object ContactAddressController extends ContactAddressController
   val keyStoreConnector: KeystoreConnector = KeystoreConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait ContactAddressController extends FrontendController with AuthorisedForTAVC{
+trait ContactAddressController extends FrontendController with AuthorisedAndEnrolledForTAVC{
 
   val keyStoreConnector: KeystoreConnector
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     keyStoreConnector.fetchAndGetFormData[ContactAddressModel](KeystoreKeys.contactAddress).map {
       case Some(data) => Ok(contactInformation.ContactAddress(contactAddressForm.fill(data)))
       case None => Ok(contactInformation.ContactAddress(contactAddressForm))
     }
   }
 
-  val submit = Authorised.async { implicit user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     contactAddressForm.bindFromRequest().fold(
       formWithErrors => {
         Future.successful(BadRequest(contactInformation.ContactAddress(formWithErrors)))

--- a/app/controllers/ContactDetailsController.scala
+++ b/app/controllers/ContactDetailsController.scala
@@ -16,10 +16,10 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
+import auth.AuthorisedAndEnrolledForTAVC
 import common.KeystoreKeys
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.KeystoreConnector
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import models.ContactDetailsModel
 import forms.ContactDetailsForm._
 import uk.gov.hmrc.play.frontend.controller.FrontendController
@@ -32,20 +32,21 @@ object ContactDetailsController extends ContactDetailsController
   val keyStoreConnector: KeystoreConnector = KeystoreConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait ContactDetailsController extends FrontendController with AuthorisedForTAVC {
+trait ContactDetailsController extends FrontendController with AuthorisedAndEnrolledForTAVC {
 
   val keyStoreConnector: KeystoreConnector
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     keyStoreConnector.fetchAndGetFormData[ContactDetailsModel](KeystoreKeys.contactDetails).map {
       case Some(data) => Ok(ContactDetails(contactDetailsForm.fill(data)))
       case None => Ok(ContactDetails(contactDetailsForm))
     }
   }
 
-  val submit = Authorised.async { implicit user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     contactDetailsForm.bindFromRequest().fold(
       formWithErrors => {
         Future.successful(BadRequest(ContactDetails(formWithErrors)))

--- a/app/controllers/DateOfIncorporationController.scala
+++ b/app/controllers/DateOfIncorporationController.scala
@@ -16,10 +16,10 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
+import auth.AuthorisedAndEnrolledForTAVC
 import common.KeystoreKeys
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.KeystoreConnector
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.Helpers.KnowledgeIntensiveHelper
 import forms.DateOfIncorporationForm._
 import models.DateOfIncorporationModel
@@ -33,19 +33,20 @@ object DateOfIncorporationController extends DateOfIncorporationController{
   val keyStoreConnector: KeystoreConnector = KeystoreConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait DateOfIncorporationController extends FrontendController with AuthorisedForTAVC {
+trait DateOfIncorporationController extends FrontendController with AuthorisedAndEnrolledForTAVC {
   val keyStoreConnector: KeystoreConnector
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     keyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](KeystoreKeys.dateOfIncorporation).map {
       case Some(data) => Ok(DateOfIncorporation(dateOfIncorporationForm.fill(data)))
       case None => Ok(DateOfIncorporation(dateOfIncorporationForm))
     }
   }
 
-  val submit = Authorised.async { implicit user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     dateOfIncorporationForm.bindFromRequest().fold(
       formWithErrors => {
         Future.successful(BadRequest(DateOfIncorporation(formWithErrors)))

--- a/app/controllers/HadPreviousRFIController.scala
+++ b/app/controllers/HadPreviousRFIController.scala
@@ -16,13 +16,14 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
+import auth.AuthorisedAndEnrolledForTAVC
 import common.{Constants, KeystoreKeys}
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.KeystoreConnector
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import forms.HadPreviousRFIForm._
 import models.HadPreviousRFIModel
 import uk.gov.hmrc.play.frontend.controller.FrontendController
+
 import scala.concurrent.Future
 import views.html._
 
@@ -45,20 +46,21 @@ object HadPreviousRFIController extends HadPreviousRFIController{
   val keyStoreConnector: KeystoreConnector = KeystoreConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait HadPreviousRFIController extends FrontendController with AuthorisedForTAVC {
+trait HadPreviousRFIController extends FrontendController with AuthorisedAndEnrolledForTAVC {
 
   val keyStoreConnector: KeystoreConnector
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     keyStoreConnector.fetchAndGetFormData[HadPreviousRFIModel](KeystoreKeys.hadPreviousRFI).map {
       case Some(data) => Ok(previousInvestment.HadPreviousRFI(hadPreviousRFIForm.fill(data)))
       case None => Ok(previousInvestment.HadPreviousRFI(hadPreviousRFIForm))
     }
   }
 
-  val submit = Authorised.async { implicit user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     hadPreviousRFIForm.bindFromRequest().fold(
       formWithErrors => {
         Future.successful(BadRequest(previousInvestment.HadPreviousRFI(formWithErrors)))

--- a/app/controllers/HowToApplyController.scala
+++ b/app/controllers/HowToApplyController.scala
@@ -16,8 +16,9 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
-import config.{FrontendAuthConnector, FrontendAppConfig}
+import auth.AuthorisedAndEnrolledForTAVC
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.EnrolmentConnector
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 
 import scala.concurrent.Future
@@ -25,16 +26,17 @@ import scala.concurrent.Future
 object HowToApplyController extends HowToApplyController{
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
 
-trait HowToApplyController extends FrontendController with AuthorisedForTAVC {
+trait HowToApplyController extends FrontendController with AuthorisedAndEnrolledForTAVC {
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     Future.successful(Ok(views.html.introduction.HowToApply()))
   }
 
-  val submit = Authorised.async { implicit user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     Future.successful(Redirect(routes.YourCompanyNeedController.show()))
   }
 }

--- a/app/controllers/IneligibleForKIController.scala
+++ b/app/controllers/IneligibleForKIController.scala
@@ -16,10 +16,10 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
+import auth.AuthorisedAndEnrolledForTAVC
 import common.{Constants, KeystoreKeys}
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.KeystoreConnector
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 import views.html.knowledgeIntensive.IneligibleForKI
 import controllers.Helpers.ControllerHelpers
@@ -31,13 +31,14 @@ object IneligibleForKIController extends IneligibleForKIController{
   val keyStoreConnector: KeystoreConnector = KeystoreConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait IneligibleForKIController extends FrontendController with AuthorisedForTAVC {
+trait IneligibleForKIController extends FrontendController with AuthorisedAndEnrolledForTAVC {
 
   val keyStoreConnector: KeystoreConnector
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     def routeRequest(backUrl: Option[String]) = {
       if (backUrl.isDefined) {
         Future.successful(Ok(IneligibleForKI(backUrl.get)))
@@ -52,7 +53,7 @@ trait IneligibleForKIController extends FrontendController with AuthorisedForTAV
     } yield route
   }
 
-  val submit = Authorised.async { implicit user => implicit request => {
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request => {
     keyStoreConnector.saveFormData(KeystoreKeys.backLinkSubsidiaries, routes.IneligibleForKIController.show().toString())
     Future.successful(Redirect(routes.SubsidiariesController.show()))
     }

--- a/app/controllers/IntroductionController.scala
+++ b/app/controllers/IntroductionController.scala
@@ -16,12 +16,9 @@
 
 package controllers
 
-import java.util.UUID
-import auth.AuthorisedForTAVC
-import config.{FrontendAuthConnector, FrontendAppConfig}
 import connectors.KeystoreConnector
 import uk.gov.hmrc.play.frontend.controller.FrontendController
-import uk.gov.hmrc.play.http.{HeaderCarrier, SessionKeys}
+import uk.gov.hmrc.play.http.{HeaderCarrier}
 import play.api.mvc._
 
 

--- a/app/controllers/InvestmentGrowController.scala
+++ b/app/controllers/InvestmentGrowController.scala
@@ -16,15 +16,14 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.KeystoreConnector
+import auth.AuthorisedAndEnrolledForTAVC
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 import models._
 import common._
 import controllers.Helpers.ControllerHelpers
 import forms.InvestmentGrowForm._
-
 
 import scala.concurrent.Future
 import views.html.investment.InvestmentGrow
@@ -34,13 +33,14 @@ object InvestmentGrowController extends InvestmentGrowController
   val keyStoreConnector: KeystoreConnector = KeystoreConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait InvestmentGrowController extends FrontendController with AuthorisedForTAVC{
+trait InvestmentGrowController extends FrontendController with AuthorisedAndEnrolledForTAVC{
 
   val keyStoreConnector: KeystoreConnector
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
 
     def routeRequest(backUrl: Option[String]) = {
       if(backUrl.isDefined) {
@@ -58,7 +58,7 @@ trait InvestmentGrowController extends FrontendController with AuthorisedForTAVC
     } yield route
   }
 
-  val submit = Authorised.async { implicit user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     investmentGrowForm.bindFromRequest.fold(
       invalidForm =>
         ControllerHelpers.getSavedBackLink(KeystoreKeys.backLinkInvestmentGrow, keyStoreConnector)(hc).flatMap {

--- a/app/controllers/IsKnowledgeIntensiveController.scala
+++ b/app/controllers/IsKnowledgeIntensiveController.scala
@@ -16,10 +16,10 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
+import auth.AuthorisedAndEnrolledForTAVC
 import common.{Constants, KeystoreKeys}
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.KeystoreConnector
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import forms.IsKnowledgeIntensiveForm._
 import models._
 import uk.gov.hmrc.play.frontend.controller.FrontendController
@@ -33,20 +33,21 @@ object IsKnowledgeIntensiveController extends IsKnowledgeIntensiveController{
   val keyStoreConnector: KeystoreConnector = KeystoreConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait IsKnowledgeIntensiveController extends FrontendController with AuthorisedForTAVC {
+trait IsKnowledgeIntensiveController extends FrontendController with AuthorisedAndEnrolledForTAVC {
 
   val keyStoreConnector: KeystoreConnector
 
-  val show = Authorised.async { implicit  user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     keyStoreConnector.fetchAndGetFormData[IsKnowledgeIntensiveModel](KeystoreKeys.isKnowledgeIntensive).map {
       case Some(data) => Ok(companyDetails.IsKnowledgeIntensive(isKnowledgeIntensiveForm.fill(data)))
       case None => Ok(companyDetails.IsKnowledgeIntensive(isKnowledgeIntensiveForm))
     }
   }
 
-  val submit = Authorised.async { implicit user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
 
     def routeRequest(kiModel: Option[KiProcessingModel], isKnowledgeIntensive: Boolean): Future[Result] = {
       kiModel match {

--- a/app/controllers/LifetimeAllowanceExceededController.scala
+++ b/app/controllers/LifetimeAllowanceExceededController.scala
@@ -16,9 +16,9 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.KeystoreConnector
+import auth.AuthorisedAndEnrolledForTAVC
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 
 import scala.concurrent.Future
@@ -27,17 +27,18 @@ object LifetimeAllowanceExceededController extends LifetimeAllowanceExceededCont
   val keyStoreConnector: KeystoreConnector = KeystoreConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait LifetimeAllowanceExceededController extends FrontendController with AuthorisedForTAVC {
+trait LifetimeAllowanceExceededController extends FrontendController with AuthorisedAndEnrolledForTAVC {
 
   val keyStoreConnector: KeystoreConnector
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     Future.successful(Ok(views.html.investment.LifetimeAllowanceExceeded()))
   }
 
-  val submit = Authorised.async { implicit user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     Future.successful(Redirect(routes.ProposedInvestmentController.show()))
   }
 }

--- a/app/controllers/NatureOfBusinessController.scala
+++ b/app/controllers/NatureOfBusinessController.scala
@@ -16,14 +16,15 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.KeystoreConnector
+import auth.AuthorisedAndEnrolledForTAVC
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 import play.api.mvc._
 import models.NatureOfBusinessModel
 import common._
 import forms.NatureOfBusinessForm._
+
 import scala.concurrent.Future
 import views.html.companyDetails.NatureOfBusiness
 
@@ -32,20 +33,21 @@ object NatureOfBusinessController extends NatureOfBusinessController
   val keyStoreConnector: KeystoreConnector = KeystoreConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait NatureOfBusinessController extends FrontendController with AuthorisedForTAVC{
+trait NatureOfBusinessController extends FrontendController with AuthorisedAndEnrolledForTAVC{
 
   val keyStoreConnector: KeystoreConnector
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     keyStoreConnector.fetchAndGetFormData[NatureOfBusinessModel](KeystoreKeys.natureOfBusiness).map {
       case Some(data) => Ok(NatureOfBusiness(natureOfBusinessForm.fill(data)))
       case None => Ok(NatureOfBusiness(natureOfBusinessForm))
     }
   }
 
-  val submit = Authorised.async { implicit user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     natureOfBusinessForm.bindFromRequest().fold(
       formWithErrors => {
         Future.successful(BadRequest(NatureOfBusiness(formWithErrors)))

--- a/app/controllers/NewGeographicalMarketController.scala
+++ b/app/controllers/NewGeographicalMarketController.scala
@@ -16,13 +16,13 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
+import auth.AuthorisedAndEnrolledForTAVC
 import common.KeystoreKeys
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.KeystoreConnector
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.Helpers.ControllerHelpers
 import forms.NewGeographicalMarketForm._
-import models.{NewGeographicalMarketModel}
+import models.NewGeographicalMarketModel
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 
 import scala.concurrent.Future
@@ -32,13 +32,14 @@ object NewGeographicalMarketController extends NewGeographicalMarketController{
   val keyStoreConnector: KeystoreConnector = KeystoreConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait NewGeographicalMarketController extends FrontendController with AuthorisedForTAVC {
+trait NewGeographicalMarketController extends FrontendController with AuthorisedAndEnrolledForTAVC {
 
   val keyStoreConnector: KeystoreConnector
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     def routeRequest(backUrl: Option[String]) = {
       if(backUrl.isDefined) {
         keyStoreConnector.fetchAndGetFormData[NewGeographicalMarketModel](KeystoreKeys.newGeographicalMarket) map {
@@ -55,7 +56,7 @@ trait NewGeographicalMarketController extends FrontendController with Authorised
     } yield route
   }
 
-  val submit = Authorised.async { implicit user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     newGeographicalMarketForm.bindFromRequest.fold(
       invalidForm =>
         ControllerHelpers.getSavedBackLink(KeystoreKeys.backLinkNewGeoMarket, keyStoreConnector)(hc).flatMap {

--- a/app/controllers/NewProductController.scala
+++ b/app/controllers/NewProductController.scala
@@ -16,10 +16,10 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
+import auth.AuthorisedAndEnrolledForTAVC
 import common.{Constants, KeystoreKeys}
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.KeystoreConnector
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import forms.NewProductForm._
 import models.{NewProductModel, SubsidiariesModel}
 import uk.gov.hmrc.play.frontend.controller.FrontendController
@@ -32,20 +32,21 @@ object NewProductController extends NewProductController{
   val keyStoreConnector: KeystoreConnector = KeystoreConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait NewProductController extends FrontendController with AuthorisedForTAVC {
+trait NewProductController extends FrontendController with AuthorisedAndEnrolledForTAVC {
 
   val keyStoreConnector: KeystoreConnector
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     keyStoreConnector.fetchAndGetFormData[NewProductModel](KeystoreKeys.newProduct).map {
       case Some(data) => Ok(NewProduct(newProductForm.fill(data)))
       case None => Ok(NewProduct(newProductForm))
     }
   }
 
-  val submit = Authorised.async { implicit user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
 
     def routeRequest(hasSubsidiaries: Option[SubsidiariesModel]): Future[Result] = {
       hasSubsidiaries match {

--- a/app/controllers/OperatingCostsController.scala
+++ b/app/controllers/OperatingCostsController.scala
@@ -16,10 +16,10 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
+import auth.AuthorisedAndEnrolledForTAVC
 import common.{Constants, KeystoreKeys}
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.{KeystoreConnector, SubmissionConnector}
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector, SubmissionConnector}
 import forms.OperatingCostsForm._
 import models.{KiProcessingModel, OperatingCostsModel}
 import play.api.mvc.{Action, Result}
@@ -34,20 +34,21 @@ object OperatingCostsController extends OperatingCostsController{
   val submissionConnector: SubmissionConnector = SubmissionConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait OperatingCostsController extends FrontendController with AuthorisedForTAVC {
+trait OperatingCostsController extends FrontendController with AuthorisedAndEnrolledForTAVC {
   val keyStoreConnector: KeystoreConnector
   val submissionConnector: SubmissionConnector
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     keyStoreConnector.fetchAndGetFormData[OperatingCostsModel](KeystoreKeys.operatingCosts).map {
       case Some(data) => Ok(OperatingCosts(operatingCostsForm.fill(data)))
       case None => Ok(OperatingCosts(operatingCostsForm))
     }
   }
 
-  val submit = Authorised.async { implicit user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
 
     def routeRequest(kiModel: Option[KiProcessingModel], isCostConditionMet: Option[Boolean]): Future[Result] = {
       kiModel match {

--- a/app/controllers/PercentageStaffWithMastersController.scala
+++ b/app/controllers/PercentageStaffWithMastersController.scala
@@ -16,10 +16,10 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
+import auth.AuthorisedAndEnrolledForTAVC
 import common.{Constants, KeystoreKeys}
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.{KeystoreConnector, SubmissionConnector}
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector, SubmissionConnector}
 import forms.PercentageStaffWithMastersForm._
 import models.{KiProcessingModel, PercentageStaffWithMastersModel}
 import uk.gov.hmrc.play.frontend.controller.FrontendController
@@ -33,21 +33,22 @@ object PercentageStaffWithMastersController extends PercentageStaffWithMastersCo
   val submissionConnector: SubmissionConnector = SubmissionConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait PercentageStaffWithMastersController extends FrontendController with AuthorisedForTAVC {
+trait PercentageStaffWithMastersController extends FrontendController with AuthorisedAndEnrolledForTAVC {
 
   val keyStoreConnector: KeystoreConnector
   val submissionConnector: SubmissionConnector
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     keyStoreConnector.fetchAndGetFormData[PercentageStaffWithMastersModel](KeystoreKeys.percentageStaffWithMasters).map {
       case Some(data) => Ok(knowledgeIntensive.PercentageStaffWithMasters(percentageStaffWithMastersForm.fill(data)))
       case None => Ok(knowledgeIntensive.PercentageStaffWithMasters(percentageStaffWithMastersForm))
     }
   }
 
-  val submit = Authorised.async { implicit user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
 
     def routeRequest(kiModel: Option[KiProcessingModel], percentageWithMasters: Boolean,
                      isSecondaryKiConditionsMet: Option[Boolean]) = {

--- a/app/controllers/PreviousBeforeDOFCSController.scala
+++ b/app/controllers/PreviousBeforeDOFCSController.scala
@@ -16,10 +16,10 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
+import auth.AuthorisedAndEnrolledForTAVC
 import common.{Constants, KeystoreKeys}
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.KeystoreConnector
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import forms.PreviousBeforeDOFCSForm._
 import models.{PreviousBeforeDOFCSModel, SubsidiariesModel}
 import uk.gov.hmrc.play.frontend.controller.FrontendController
@@ -33,20 +33,21 @@ object  PreviousBeforeDOFCSController extends PreviousBeforeDOFCSController {
   val keyStoreConnector: KeystoreConnector = KeystoreConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait PreviousBeforeDOFCSController extends FrontendController with AuthorisedForTAVC {
+trait PreviousBeforeDOFCSController extends FrontendController with AuthorisedAndEnrolledForTAVC {
 
   val keyStoreConnector: KeystoreConnector
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     keyStoreConnector.fetchAndGetFormData[PreviousBeforeDOFCSModel](KeystoreKeys.previousBeforeDOFCS).map {
       case Some(data) => Ok(investment.PreviousBeforeDOFCS(previousBeforeDOFCSForm.fill(data)))
       case None => Ok(investment.PreviousBeforeDOFCS(previousBeforeDOFCSForm))
     }
   }
 
-  val submit = Authorised.async { implicit user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
 
     def routeRequest(date: Option[SubsidiariesModel]): Future[Result] = {
       date match {

--- a/app/controllers/PreviousSchemeController.scala
+++ b/app/controllers/PreviousSchemeController.scala
@@ -16,13 +16,14 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
+import auth.AuthorisedAndEnrolledForTAVC
 import common.KeystoreKeys
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.KeystoreConnector
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 import play.api.mvc._
 import controllers.Helpers.{ControllerHelpers, PreviousSchemesHelper}
+
 import scala.concurrent.Future
 import views.html.previousInvestment.PreviousScheme
 import forms.PreviousSchemeForm._
@@ -32,13 +33,14 @@ object PreviousSchemeController extends PreviousSchemeController
   val keyStoreConnector: KeystoreConnector = KeystoreConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait PreviousSchemeController extends FrontendController with AuthorisedForTAVC {
+trait PreviousSchemeController extends FrontendController with AuthorisedAndEnrolledForTAVC {
 
   val keyStoreConnector: KeystoreConnector
 
-  def show(id: Option[Int]): Action[AnyContent] = Authorised.async { implicit user => implicit request =>
+  def show(id: Option[Int]): Action[AnyContent] = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     def routeRequest(backUrl: Option[String]) = {
       if (backUrl.isDefined) {
         id match {
@@ -63,7 +65,7 @@ trait PreviousSchemeController extends FrontendController with AuthorisedForTAVC
     } yield route
   }
 
-  val submit = Authorised.async { implicit  user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     previousSchemeForm.bindFromRequest().fold(
       formWithErrors => {
         ControllerHelpers.getSavedBackLink(KeystoreKeys.backLinkPreviousScheme, keyStoreConnector).flatMap(url =>

--- a/app/controllers/ProposedInvestmentController.scala
+++ b/app/controllers/ProposedInvestmentController.scala
@@ -16,9 +16,9 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.{KeystoreConnector, SubmissionConnector}
+import auth.AuthorisedAndEnrolledForTAVC
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector, SubmissionConnector}
 import controllers.Helpers.{ControllerHelpers, PreviousSchemesHelper}
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 import play.api.mvc._
@@ -36,14 +36,15 @@ object ProposedInvestmentController extends ProposedInvestmentController
   val submissionConnector: SubmissionConnector = SubmissionConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait ProposedInvestmentController extends FrontendController with AuthorisedForTAVC {
+trait ProposedInvestmentController extends FrontendController with AuthorisedAndEnrolledForTAVC {
 
   val keyStoreConnector: KeystoreConnector
   val submissionConnector: SubmissionConnector
 
-  val show: Action[AnyContent] = Authorised.async { implicit user => implicit request =>
+  val show: Action[AnyContent] = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     def routeRequest(backUrl: Option[String]) = {
       if (backUrl.isDefined) {
         keyStoreConnector.fetchAndGetFormData[ProposedInvestmentModel](KeystoreKeys.proposedInvestment).map {
@@ -62,7 +63,7 @@ trait ProposedInvestmentController extends FrontendController with AuthorisedFor
     } yield route
   }
 
-  val submit = Authorised.async { implicit  user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
 
     def routeRequest(kiModel: Option[KiProcessingModel], isLifeTimeAllowanceExceeded: Option[Boolean]): Future[Result] = {
       kiModel match {

--- a/app/controllers/QualifyingForSchemeController.scala
+++ b/app/controllers/QualifyingForSchemeController.scala
@@ -16,9 +16,9 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.KeystoreConnector
+import auth.AuthorisedAndEnrolledForTAVC
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 
 import scala.concurrent.Future
@@ -28,15 +28,16 @@ object QualifyingForSchemeController extends QualifyingForSchemeController
   val keyStoreConnector: KeystoreConnector = KeystoreConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait QualifyingForSchemeController extends FrontendController with AuthorisedForTAVC {
+trait QualifyingForSchemeController extends FrontendController with AuthorisedAndEnrolledForTAVC {
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     Future.successful(Ok(views.html.introduction.qualifyingForScheme()))
   }
 
-  val submit = Authorised.async { implicit user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     Future.successful(Redirect(routes.WhatWeAskYouController.show()))
   }
 }

--- a/app/controllers/RegisteredAddressController.scala
+++ b/app/controllers/RegisteredAddressController.scala
@@ -16,15 +16,16 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
+import auth.AuthorisedAndEnrolledForTAVC
 import common.KeystoreKeys
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.KeystoreConnector
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import forms.RegisteredAddressForm._
 import models.RegisteredAddressModel
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 import play.api.mvc._
 import views.html._
+
 import scala.concurrent.Future
 
 object RegisteredAddressController extends RegisteredAddressController
@@ -32,20 +33,21 @@ object RegisteredAddressController extends RegisteredAddressController
   val keyStoreConnector: KeystoreConnector = KeystoreConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait RegisteredAddressController extends FrontendController with AuthorisedForTAVC {
+trait RegisteredAddressController extends FrontendController with AuthorisedAndEnrolledForTAVC {
 
   val keyStoreConnector: KeystoreConnector
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     keyStoreConnector.fetchAndGetFormData[RegisteredAddressModel](KeystoreKeys.registeredAddress).map {
       case Some(data) => Ok(companyDetails.RegisteredAddress(registeredAddressForm.fill(data)))
       case None => Ok(companyDetails.RegisteredAddress(registeredAddressForm))
     }
   }
 
-  val submit = Authorised.async { implicit user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     registeredAddressForm.bindFromRequest().fold(
       formWithErrors => {
         Future.successful(BadRequest(companyDetails.RegisteredAddress(formWithErrors)))

--- a/app/controllers/ReviewPreviousSchemesController.scala
+++ b/app/controllers/ReviewPreviousSchemesController.scala
@@ -16,10 +16,10 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
+import auth.AuthorisedAndEnrolledForTAVC
 import common.KeystoreKeys
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.KeystoreConnector
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.Helpers.PreviousSchemesHelper
 import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.play.frontend.controller.FrontendController
@@ -31,35 +31,36 @@ object ReviewPreviousSchemesController extends ReviewPreviousSchemesController {
   val keyStoreConnector: KeystoreConnector = KeystoreConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait ReviewPreviousSchemesController extends FrontendController with AuthorisedForTAVC{
+trait ReviewPreviousSchemesController extends FrontendController with AuthorisedAndEnrolledForTAVC{
 
   val keyStoreConnector: KeystoreConnector
 
-  val show = Authorised.async { implicit  user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     PreviousSchemesHelper.getAllInvestmentFromKeystore(keyStoreConnector).flatMap(previousSchemes =>
       Future.successful(Ok(ReviewPreviousSchemes(previousSchemes))))
   }
 
-  def add: Action[AnyContent] = Authorised.async { implicit user => implicit request =>
+  def add: Action[AnyContent] = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     keyStoreConnector.saveFormData(KeystoreKeys.backLinkPreviousScheme, routes.ReviewPreviousSchemesController.show().toString())
     Future.successful(Redirect(routes.PreviousSchemeController.show(None)))
   }
 
-  def change(id: Int): Action[AnyContent] = Authorised.async { implicit user => implicit request =>
+  def change(id: Int): Action[AnyContent] = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     keyStoreConnector.saveFormData(KeystoreKeys.backLinkPreviousScheme, routes.ReviewPreviousSchemesController.show().toString())
     Future.successful(Redirect(routes.PreviousSchemeController.show(Some(id))))
   }
 
-  def remove(id: Int): Action[AnyContent] = Authorised.async { implicit user => implicit request =>
+  def remove(id: Int): Action[AnyContent] = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     keyStoreConnector.saveFormData(KeystoreKeys.backLinkPreviousScheme, routes.ReviewPreviousSchemesController.show().toString())
     PreviousSchemesHelper.removeKeystorePreviousInvestment(keyStoreConnector, id).map {
       _ => Redirect(routes.ReviewPreviousSchemesController.show())
     }
   }
 
-  val submit = Authorised.async { implicit user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     keyStoreConnector.saveFormData(KeystoreKeys.backLinkProposedInvestment, routes.ReviewPreviousSchemesController.show().toString())
     PreviousSchemesHelper.getAllInvestmentFromKeystore(keyStoreConnector).flatMap(previousSchemes =>
       if(previousSchemes.nonEmpty) Future.successful(Redirect(routes.ProposedInvestmentController.show()))

--- a/app/controllers/SubsidiariesContoller.scala
+++ b/app/controllers/SubsidiariesContoller.scala
@@ -16,12 +16,12 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
+import auth.AuthorisedAndEnrolledForTAVC
 import common.KeystoreKeys
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.KeystoreConnector
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.Helpers.ControllerHelpers
-import models.{SubsidiariesModel}
+import models.SubsidiariesModel
 import forms.SubsidiariesForm._
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 import play.api.mvc._
@@ -34,13 +34,14 @@ object SubsidiariesController extends SubsidiariesController {
   val keyStoreConnector: KeystoreConnector = KeystoreConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait SubsidiariesController extends FrontendController with AuthorisedForTAVC {
+trait SubsidiariesController extends FrontendController with AuthorisedAndEnrolledForTAVC {
 
   val keyStoreConnector: KeystoreConnector
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
 
     def routeRequest(backUrl: Option[String]) = {
       if (backUrl.isDefined) {
@@ -62,7 +63,7 @@ trait SubsidiariesController extends FrontendController with AuthorisedForTAVC {
     } yield route
   }
 
-  val submit = Authorised.async { implicit user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     subsidiariesForm.bindFromRequest.fold(
       invalidForm => ControllerHelpers.getSavedBackLink(KeystoreKeys.backLinkSubsidiaries, keyStoreConnector)(hc)
         .flatMap(url => Future.successful(BadRequest(companyDetails.Subsidiaries(invalidForm, url.

--- a/app/controllers/SubsidiariesNinetyOwnedController.scala
+++ b/app/controllers/SubsidiariesNinetyOwnedController.scala
@@ -16,10 +16,10 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
+import auth.AuthorisedAndEnrolledForTAVC
 import common.KeystoreKeys
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.KeystoreConnector
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import forms.SubsidiariesNinetyOwnedForm._
 import models.SubsidiariesNinetyOwnedModel
 import uk.gov.hmrc.play.frontend.controller.FrontendController
@@ -31,20 +31,21 @@ object SubsidiariesNinetyOwnedController extends SubsidiariesNinetyOwnedControll
   val keyStoreConnector: KeystoreConnector =  KeystoreConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait SubsidiariesNinetyOwnedController extends FrontendController with AuthorisedForTAVC {
+trait SubsidiariesNinetyOwnedController extends FrontendController with AuthorisedAndEnrolledForTAVC {
 
   val keyStoreConnector: KeystoreConnector
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     keyStoreConnector.fetchAndGetFormData[SubsidiariesNinetyOwnedModel](KeystoreKeys.subsidiariesNinetyOwned).map {
       case Some(data) => Ok(SubsidiariesNinetyOwned(subsidiariesNinetyOwnedForm.fill(data)))
       case None => Ok(SubsidiariesNinetyOwned(subsidiariesNinetyOwnedForm))
     }
   }
 
-  val submit = Authorised.async { implicit user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     subsidiariesNinetyOwnedForm.bindFromRequest().fold(
       formWithErrors => {
         Future.successful(BadRequest(SubsidiariesNinetyOwned(formWithErrors)))

--- a/app/controllers/SubsidiariesSpendingInvestmentController.scala
+++ b/app/controllers/SubsidiariesSpendingInvestmentController.scala
@@ -32,10 +32,10 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
+import auth.AuthorisedAndEnrolledForTAVC
 import common.{Constants, KeystoreKeys}
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.KeystoreConnector
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.Helpers.ControllerHelpers
 import forms.SubsidiariesSpendingInvestmentForm._
 import models.SubsidiariesSpendingInvestmentModel
@@ -48,13 +48,14 @@ object SubsidiariesSpendingInvestmentController extends SubsidiariesSpendingInve
   val keyStoreConnector: KeystoreConnector = KeystoreConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait SubsidiariesSpendingInvestmentController extends FrontendController with AuthorisedForTAVC{
+trait SubsidiariesSpendingInvestmentController extends FrontendController with AuthorisedAndEnrolledForTAVC{
 
   val keyStoreConnector: KeystoreConnector
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     def routeRequest(backUrl: Option[String]) = {
       if(backUrl.isDefined) {
         keyStoreConnector.fetchAndGetFormData[SubsidiariesSpendingInvestmentModel](KeystoreKeys.subsidiariesSpendingInvestment).map {
@@ -70,7 +71,7 @@ trait SubsidiariesSpendingInvestmentController extends FrontendController with A
     } yield route
   }
 
-  val submit = Authorised.async { implicit user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     subsidiariesSpendingInvestmentForm.bindFromRequest.fold(
       invalidForm =>
         ControllerHelpers.getSavedBackLink(KeystoreKeys.backLinkSubSpendingInvestment, keyStoreConnector)(hc).flatMap {

--- a/app/controllers/SupportingDocumentsController.scala
+++ b/app/controllers/SupportingDocumentsController.scala
@@ -16,10 +16,10 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
+import auth.AuthorisedAndEnrolledForTAVC
 import common.KeystoreKeys
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.KeystoreConnector
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.Helpers.ControllerHelpers
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 import views.html.supportingDocuments.SupportingDocuments
@@ -31,13 +31,14 @@ object SupportingDocumentsController extends SupportingDocumentsController
   val keyStoreConnector: KeystoreConnector = KeystoreConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait SupportingDocumentsController extends FrontendController with AuthorisedForTAVC {
+trait SupportingDocumentsController extends FrontendController with AuthorisedAndEnrolledForTAVC {
 
   val keyStoreConnector: KeystoreConnector
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
 
     ControllerHelpers.getSavedBackLink(KeystoreKeys.backLinkSupportingDocs, keyStoreConnector)(hc).flatMap {
       case Some(backlink) => Future.successful(Ok(SupportingDocuments(backlink)))
@@ -45,7 +46,7 @@ trait SupportingDocumentsController extends FrontendController with AuthorisedFo
     }
   }
 
-  val submit = Authorised.async { implicit user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     Future.successful(Redirect(routes.CheckAnswersController.show()))
   }
 }

--- a/app/controllers/TaxpayerReferenceController.scala
+++ b/app/controllers/TaxpayerReferenceController.scala
@@ -16,14 +16,15 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.KeystoreConnector
+import auth.AuthorisedAndEnrolledForTAVC
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 import play.api.mvc._
 import models.TaxpayerReferenceModel
 import common._
 import forms.TaxPayerReferenceForm._
+
 import scala.concurrent.Future
 import views.html.companyDetails.TaxpayerReference
 
@@ -32,20 +33,21 @@ object TaxpayerReferenceController extends TaxpayerReferenceController
   val keyStoreConnector: KeystoreConnector = KeystoreConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait TaxpayerReferenceController extends FrontendController with AuthorisedForTAVC{
+trait TaxpayerReferenceController extends FrontendController with AuthorisedAndEnrolledForTAVC{
 
   val keyStoreConnector: KeystoreConnector
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     keyStoreConnector.fetchAndGetFormData[TaxpayerReferenceModel](KeystoreKeys.taxpayerReference).map {
       case Some(data) => Ok(TaxpayerReference(taxPayerReferenceForm.fill(data)))
       case None => Ok(TaxpayerReference(taxPayerReferenceForm))
     }
   }
 
-  val submit = Authorised.async { implicit user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     taxPayerReferenceForm.bindFromRequest().fold(
       formWithErrors => {
         Future.successful(BadRequest(TaxpayerReference(formWithErrors)))

--- a/app/controllers/TenYearPlanController.scala
+++ b/app/controllers/TenYearPlanController.scala
@@ -16,9 +16,9 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.{KeystoreConnector, SubmissionConnector}
+import auth.AuthorisedAndEnrolledForTAVC
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector, SubmissionConnector}
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 import play.api.mvc._
 import models.{KiProcessingModel, TenYearPlanModel}
@@ -33,21 +33,22 @@ object TenYearPlanController extends TenYearPlanController {
   val submissionConnector: SubmissionConnector = SubmissionConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait TenYearPlanController extends FrontendController with AuthorisedForTAVC {
+trait TenYearPlanController extends FrontendController with AuthorisedAndEnrolledForTAVC {
 
   val keyStoreConnector: KeystoreConnector
   val submissionConnector: SubmissionConnector
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     keyStoreConnector.fetchAndGetFormData[TenYearPlanModel](KeystoreKeys.tenYearPlan).map {
       case Some(data) => Ok(TenYearPlan(tenYearPlanForm.fill(data)))
       case None => Ok(TenYearPlan(tenYearPlanForm))
     }
   }
 
-  val submit = Authorised.async { implicit user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
 
     def routeRequest(kiModel: Option[KiProcessingModel], hasTenYearPlan: Boolean,
                      isSecondaryKiConditionsMet: Option[Boolean]): Future[Result] = {

--- a/app/controllers/UsedInvestmentReasonBeforeController.scala
+++ b/app/controllers/UsedInvestmentReasonBeforeController.scala
@@ -16,10 +16,10 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
+import auth.AuthorisedAndEnrolledForTAVC
 import common.{Constants, KeystoreKeys}
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.KeystoreConnector
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import forms.UsedInvestmentReasonBeforeForm._
 import models.UsedInvestmentReasonBeforeModel
 import uk.gov.hmrc.play.frontend.controller.FrontendController
@@ -32,20 +32,21 @@ object UsedInvestmentReasonBeforeController extends UsedInvestmentReasonBeforeCo
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
   val keyStoreConnector: KeystoreConnector = KeystoreConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait UsedInvestmentReasonBeforeController extends FrontendController with AuthorisedForTAVC{
+trait UsedInvestmentReasonBeforeController extends FrontendController with AuthorisedAndEnrolledForTAVC{
 
   val keyStoreConnector: KeystoreConnector
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     keyStoreConnector.fetchAndGetFormData[UsedInvestmentReasonBeforeModel](KeystoreKeys.usedInvestmentReasonBefore).map {
       case Some(data) => Ok(UsedInvestmentReasonBefore(usedInvestmentReasonBeforeForm.fill(data)))
       case None => Ok(UsedInvestmentReasonBefore(usedInvestmentReasonBeforeForm))
     }
   }
 
-  val submit = Authorised.async { implicit userr => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit userr => implicit request =>
     usedInvestmentReasonBeforeForm.bindFromRequest().fold(
       formWithErrors => {
         Future.successful(BadRequest(UsedInvestmentReasonBefore(formWithErrors)))

--- a/app/controllers/WhatWeAskYouController.scala
+++ b/app/controllers/WhatWeAskYouController.scala
@@ -16,9 +16,9 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.KeystoreConnector
+import auth.AuthorisedAndEnrolledForTAVC
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 import play.api.mvc._
 
@@ -29,15 +29,16 @@ object WhatWeAskYouController extends WhatWeAskYouController
   val keyStoreConnector: KeystoreConnector = KeystoreConnector
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait WhatWeAskYouController extends FrontendController with AuthorisedForTAVC{
+trait WhatWeAskYouController extends FrontendController with AuthorisedAndEnrolledForTAVC{
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     Future.successful(Ok(views.html.introduction.WhatWeAskYou()))
   }
 
-  val submit = Authorised.async { implicit user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     Future.successful(Redirect(routes.TaxpayerReferenceController.show()))
   }
 }

--- a/app/controllers/WhatWillUseForController.scala
+++ b/app/controllers/WhatWillUseForController.scala
@@ -16,14 +16,14 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
+import auth.AuthorisedAndEnrolledForTAVC
 import common.KeystoreKeys
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.KeystoreConnector
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import forms.WhatWillUseForForm._
 import models._
 import uk.gov.hmrc.play.frontend.controller.FrontendController
-import play.api.mvc.{Action, Result}
+import play.api.mvc.Result
 import utils.Validation
 import views.html.investment.WhatWillUseFor
 import common.Constants
@@ -35,20 +35,21 @@ object WhatWillUseForController extends WhatWillUseForController{
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
   val keyStoreConnector: KeystoreConnector = KeystoreConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait WhatWillUseForController extends FrontendController with AuthorisedForTAVC {
+trait WhatWillUseForController extends FrontendController with AuthorisedAndEnrolledForTAVC {
 
   val keyStoreConnector: KeystoreConnector
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     keyStoreConnector.fetchAndGetFormData[WhatWillUseForModel](KeystoreKeys.whatWillUseFor).map {
       case Some(data) => Ok(WhatWillUseFor(whatWillUseForForm.fill(data)))
       case None => Ok(WhatWillUseFor(whatWillUseForForm))
     }
   }
 
-  val submit = Authorised.async { implicit user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
 
     def routeRequest(kiModel: Option[KiProcessingModel], prevRFI: Option[HadPreviousRFIModel],
                      comSale: Option[CommercialSaleModel], hasSub: Option[SubsidiariesModel]): Future[Result] = {

--- a/app/controllers/YourCompanyNeedController.scala
+++ b/app/controllers/YourCompanyNeedController.scala
@@ -16,35 +16,37 @@
 
 package controllers
 
-import auth.AuthorisedForTAVC
+import auth.AuthorisedAndEnrolledForTAVC
 import common.KeystoreKeys
-import config.{FrontendAuthConnector, FrontendAppConfig}
-import connectors.KeystoreConnector
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import forms.YourCompanyNeedForm._
 import models.YourCompanyNeedModel
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 import play.api.mvc._
 import views.html._
+
 import scala.concurrent.Future
 
 object YourCompanyNeedController extends YourCompanyNeedController{
   override lazy val applicationConfig = FrontendAppConfig
   override lazy val authConnector = FrontendAuthConnector
   val keyStoreConnector: KeystoreConnector = KeystoreConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
 }
 
-trait YourCompanyNeedController extends FrontendController with AuthorisedForTAVC{
+trait YourCompanyNeedController extends FrontendController with AuthorisedAndEnrolledForTAVC{
 
   val keyStoreConnector: KeystoreConnector
 
-  val show = Authorised.async { implicit user => implicit request =>
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     keyStoreConnector.fetchAndGetFormData[YourCompanyNeedModel](KeystoreKeys.yourCompanyNeed).map {
       case Some(data) => Ok(introduction.YourCompanyNeed(yourCompanyNeedForm.fill(data)))
       case None => Ok(introduction.YourCompanyNeed(yourCompanyNeedForm))
     }
   }
 
-  val submit = Authorised.async { implicit user => implicit request =>
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     yourCompanyNeedForm.bindFromRequest().fold(
       formWithErrors => {
         Future.successful(BadRequest(introduction.YourCompanyNeed(formWithErrors)))

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -137,3 +137,7 @@ not-authorised-callback {
 introduction {
   url="http://localhost:9635/investment-tax-relief/your-company-need"
 }
+
+investment-tax-relief-subscription {
+  url="http://localhost:9636/investment-tax-relief-subscription/"
+}

--- a/test/auth/AuthEnrolledTestController.scala
+++ b/test/auth/AuthEnrolledTestController.scala
@@ -22,13 +22,13 @@ import uk.gov.hmrc.play.frontend.controller.FrontendController
 
 import scala.concurrent.Future
 
-object AuthTestController extends AuthTestController with MockitoSugar {
+object AuthEnrolledTestController extends AuthEnrolledTestController with MockitoSugar {
   override lazy val applicationConfig = mockConfig
   override lazy val authConnector = mockAuthConnector
   override lazy val enrolmentConnector = mock[EnrolmentConnector]
 }
 
-trait AuthTestController extends FrontendController with AuthorisedAndEnrolledForTAVC {
+trait AuthEnrolledTestController extends FrontendController with AuthorisedAndEnrolledForTAVC {
 
   val authorisedAsyncAction = AuthorisedAndEnrolled.async {
     implicit user =>  implicit request => Future.successful(Ok)

--- a/test/auth/AuthTestController.scala
+++ b/test/auth/AuthTestController.scala
@@ -16,23 +16,25 @@
 
 package auth
 
+import connectors.EnrolmentConnector
+import org.scalatest.mock.MockitoSugar
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 
 import scala.concurrent.Future
 
-object AuthTestController extends AuthTestController {
-
+object AuthTestController extends AuthTestController with MockitoSugar {
   override lazy val applicationConfig = mockConfig
   override lazy val authConnector = mockAuthConnector
+  override lazy val enrolmentConnector = mock[EnrolmentConnector]
 }
 
-trait AuthTestController extends FrontendController with AuthorisedForTAVC {
+trait AuthTestController extends FrontendController with AuthorisedAndEnrolledForTAVC {
 
-  val authorisedAsyncAction = Authorised.async {
+  val authorisedAsyncAction = AuthorisedAndEnrolled.async {
     implicit user =>  implicit request => Future.successful(Ok)
   }
 
-  val authorisedAction = Authorised {
+  val authorisedAction = AuthorisedAndEnrolled {
     implicit user =>  implicit request => Ok
   }
 

--- a/test/auth/TAVCAuthEnrolledSpec.scala
+++ b/test/auth/TAVCAuthEnrolledSpec.scala
@@ -30,7 +30,7 @@ import uk.gov.hmrc.play.http.HeaderCarrier
 
 import scala.concurrent.Future
 
-class TAVCAuthSpec extends UnitSpec with WithFakeApplication with MockitoSugar {
+class TAVCAuthEnrolledSpec extends UnitSpec with WithFakeApplication with MockitoSugar {
 
   "Government Gateway Provider" should {
     "have an account type additional parameter set to organisation" in {
@@ -73,7 +73,7 @@ class TAVCAuthSpec extends UnitSpec with WithFakeApplication with MockitoSugar {
   "Calling authenticated async action with no login session" should {
     "result in a redirect to login" in {
 
-      val result = AuthTestController.authorisedAsyncAction(fakeRequest)
+      val result = AuthEnrolledTestController.authorisedAsyncAction(fakeRequest)
       status(result) shouldBe Status.SEE_OTHER
       redirectLocation(result) shouldBe Some(s"/gg/sign-in?continue=${URLEncoder.encode(MockConfig.introductionUrl)}&origin=investment-tax-relief-submission-frontend&accountType=organisation")
     }
@@ -82,9 +82,9 @@ class TAVCAuthSpec extends UnitSpec with WithFakeApplication with MockitoSugar {
   "Calling authenticated async action with a default GG login session with no TAVC enrolment" should {
     "result in a redirect to subscription" in {
       implicit val hc = HeaderCarrier()
-      when(AuthTestController.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      when(AuthEnrolledTestController.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
         .thenReturn(Future.successful(None))
-      val result = AuthTestController.authorisedAsyncAction(authenticatedFakeRequest(AuthenticationProviderIds.GovernmentGatewayId))
+      val result = AuthEnrolledTestController.authorisedAsyncAction(authenticatedFakeRequest(AuthenticationProviderIds.GovernmentGatewayId))
       redirectLocation(result) shouldBe Some("/investment-tax-relief-subscription/")
     }
   }
@@ -93,9 +93,9 @@ class TAVCAuthSpec extends UnitSpec with WithFakeApplication with MockitoSugar {
     "result in a status OK" in {
       implicit val hc = HeaderCarrier()
       val enrolledUser = Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated")
-      when(AuthTestController.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      when(AuthEnrolledTestController.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
         .thenReturn(Future.successful(Option(enrolledUser)))
-      val result = AuthTestController.authorisedAsyncAction(authenticatedFakeRequest(AuthenticationProviderIds.GovernmentGatewayId))
+      val result = AuthEnrolledTestController.authorisedAsyncAction(authenticatedFakeRequest(AuthenticationProviderIds.GovernmentGatewayId))
       status(result) shouldBe Status.OK
     }
   }

--- a/test/controllers/AcknowledgementControllerSpec.scala
+++ b/test/controllers/AcknowledgementControllerSpec.scala
@@ -32,7 +32,7 @@ import uk.gov.hmrc.play.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 import java.net.URLEncoder
 
-import auth.AuthTestController.{INTERNAL_SERVER_ERROR => _, OK => _, SEE_OTHER => _, _}
+import auth.AuthEnrolledTestController.{INTERNAL_SERVER_ERROR => _, OK => _, SEE_OTHER => _, _}
 
 import scala.concurrent.Future
 

--- a/test/controllers/AcknowledgementControllerSpec.scala
+++ b/test/controllers/AcknowledgementControllerSpec.scala
@@ -58,6 +58,12 @@ class AcknowledgementControllerSpec extends UnitSpec  with Mockito with WithFake
       val submissionConnector: SubmissionConnector = mockSubmission
       override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    def mockEnrolledRequest: Unit = when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+
+    def mockNotEnrolledRequest: Unit = when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(None))
   }
 
   implicit val hc = HeaderCarrier()
@@ -94,8 +100,7 @@ class AcknowledgementControllerSpec extends UnitSpec  with Mockito with WithFake
         .thenReturn(Future.successful(Option(yourCompanyNeed)))
       when(mockSubmission.submitAdvancedAssurance(Matchers.eq(submissionRequestValid))(Matchers.any()))
         .thenReturn(Future.successful(HttpResponse(OK, Some(Json.toJson(submissionResponse)))))
-      when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val result = controller.show.apply(authorisedFakeRequest)
       status(result) shouldBe OK
     }
@@ -107,8 +112,7 @@ class AcknowledgementControllerSpec extends UnitSpec  with Mockito with WithFake
         .thenReturn(Future.successful(Option(yourCompanyNeed)))
       when(mockSubmission.submitAdvancedAssurance(Matchers.eq(submissionRequestInvalid))(Matchers.any()))
         .thenReturn(Future.successful(HttpResponse(INTERNAL_SERVER_ERROR)))
-      when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val result = controller.show.apply(authorisedFakeRequest)
       status(result) shouldBe INTERNAL_SERVER_ERROR
     }
@@ -122,8 +126,7 @@ class AcknowledgementControllerSpec extends UnitSpec  with Mockito with WithFake
         .thenReturn(Future.successful(Option(yourCompanyNeed)))
       when(mockSubmission.submitAdvancedAssurance(Matchers.eq(submissionRequestValid))(Matchers.any()))
         .thenReturn(Future.successful(HttpResponse(OK, Some(Json.toJson(submissionResponse)))))
-      when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       val result = controller.show.apply(authorisedFakeRequest)
       status(result) shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(FrontendAppConfig.subscriptionUrl)

--- a/test/controllers/CheckAnswersControllerSpec.scala
+++ b/test/controllers/CheckAnswersControllerSpec.scala
@@ -34,10 +34,10 @@ package controllers
 
 import java.net.URLEncoder
 
-import auth.{MockAuthConnector, MockConfig}
+import auth.{Enrolment, Identifier, MockAuthConnector, MockConfig}
 import common.{Constants, KeystoreKeys}
 import config.{FrontendAppConfig, FrontendAuthConnector}
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.helpers.FakeRequestHelper
 import models.{ContactDetailsModel, _}
 import org.mockito.Matchers
@@ -59,6 +59,7 @@ class CheckAnswersControllerSpec extends UnitSpec with MockitoSugar with BeforeA
     override lazy val applicationConfig = FrontendAppConfig
     override lazy val authConnector = MockAuthConnector
     val keyStoreConnector: KeystoreConnector = mockKeyStoreConnector
+    override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
   val yourCompanyNeedModel = YourCompanyNeedModel("")
@@ -103,7 +104,7 @@ class CheckAnswersControllerSpec extends UnitSpec with MockitoSugar with BeforeA
     }
   }
 
-  "Sending a GET request to CheckAnswersController with a populated set of models when authenticated" should {
+  "Sending a GET request to CheckAnswersController with a populated set of models when authenticated and enrolled" should {
     "return a 200 when the page is loaded" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[YourCompanyNeedModel](Matchers.eq(KeystoreKeys.yourCompanyNeed))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(yourCompanyNeedModel)))
@@ -149,6 +150,8 @@ class CheckAnswersControllerSpec extends UnitSpec with MockitoSugar with BeforeA
         Matchers.any())).thenReturn(Future.successful(Option(contactDetailsModel)))
       when(mockKeyStoreConnector.fetchAndGetFormData[InvestmentGrowModel](Matchers.eq(KeystoreKeys.investmentGrow))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(investmentGrowModel)))
+      when(CheckAnswersControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
 
       showWithSessionAndAuth(CheckAnswersControllerTest.show())(
         result => status(result) shouldBe OK
@@ -156,7 +159,7 @@ class CheckAnswersControllerSpec extends UnitSpec with MockitoSugar with BeforeA
     }
   }
 
-  "Sending a GET request to CheckAnswersController with an empty set of models when authenticated" should {
+  "Sending a GET request to CheckAnswersController with an empty set of models when authenticated and enrolled" should {
     "return a 200 when the page is loaded" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[YourCompanyNeedModel](Matchers.eq(KeystoreKeys.yourCompanyNeed))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
@@ -202,6 +205,8 @@ class CheckAnswersControllerSpec extends UnitSpec with MockitoSugar with BeforeA
         Matchers.any())).thenReturn(Future.successful(None))
       when(mockKeyStoreConnector.fetchAndGetFormData[InvestmentGrowModel](Matchers.eq(KeystoreKeys.investmentGrow))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
+      when(CheckAnswersControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
 
       showWithSessionAndAuth(CheckAnswersControllerTest.show())(
         result => status(result) shouldBe OK
@@ -209,6 +214,63 @@ class CheckAnswersControllerSpec extends UnitSpec with MockitoSugar with BeforeA
     }
   }
 
+  "Sending an Authenticated and NOT Enrolled GET request with a session to CheckAnswersControllerTest" should {
+    "redirect to the TAVC Subscription Service" in {
+      when(mockKeyStoreConnector.fetchAndGetFormData[YourCompanyNeedModel](Matchers.eq(KeystoreKeys.yourCompanyNeed))(Matchers.any(), Matchers.any()))
+        .thenReturn(Future.successful(None))
+      when(mockKeyStoreConnector.fetchAndGetFormData[TaxpayerReferenceModel](Matchers.eq(KeystoreKeys.taxpayerReference))(Matchers.any(), Matchers.any()))
+        .thenReturn(Future.successful(None))
+      when(mockKeyStoreConnector.fetchAndGetFormData[RegisteredAddressModel](Matchers.eq(KeystoreKeys.registeredAddress))(Matchers.any(),
+        Matchers.any())).thenReturn(Future.successful(None))
+      when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.eq(KeystoreKeys.dateOfIncorporation))(Matchers.any(), Matchers.any()))
+        .thenReturn(Future.successful(None))
+      when(mockKeyStoreConnector.fetchAndGetFormData[NatureOfBusinessModel](Matchers.eq(KeystoreKeys.natureOfBusiness))(Matchers.any(), Matchers.any()))
+        .thenReturn(Future.successful(None))
+      when(mockKeyStoreConnector.fetchAndGetFormData[CommercialSaleModel](Matchers.eq(KeystoreKeys.commercialSale))(Matchers.any(),
+        Matchers.any())).thenReturn(Future.successful(None))
+      when(mockKeyStoreConnector.fetchAndGetFormData[IsKnowledgeIntensiveModel](Matchers.eq(KeystoreKeys.isKnowledgeIntensive))(Matchers.any(), Matchers.any()))
+        .thenReturn(Future.successful(None))
+      when(mockKeyStoreConnector.fetchAndGetFormData[OperatingCostsModel](Matchers.eq(KeystoreKeys.operatingCosts))(Matchers.any(), Matchers.any()))
+        .thenReturn(Future.successful(None))
+      when(mockKeyStoreConnector.fetchAndGetFormData[PercentageStaffWithMastersModel](Matchers.eq(KeystoreKeys.percentageStaffWithMasters))(Matchers.any(),
+        Matchers.any())).thenReturn(Future.successful(None))
+      when(mockKeyStoreConnector.fetchAndGetFormData[TenYearPlanModel](Matchers.eq(KeystoreKeys.tenYearPlan))(Matchers.any(), Matchers.any()))
+        .thenReturn(Future.successful(None))
+      when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesModel](Matchers.eq(KeystoreKeys.subsidiaries))(Matchers.any(), Matchers.any()))
+        .thenReturn(Future.successful(None))
+      when(mockKeyStoreConnector.fetchAndGetFormData[HadPreviousRFIModel](Matchers.eq(KeystoreKeys.hadPreviousRFI))(Matchers.any(),
+        Matchers.any())).thenReturn(Future.successful(None))
+      when(mockKeyStoreConnector.fetchAndGetFormData[ProposedInvestmentModel](Matchers.eq(KeystoreKeys.proposedInvestment))(Matchers.any(), Matchers.any()))
+        .thenReturn(Future.successful(None))
+      when(mockKeyStoreConnector.fetchAndGetFormData[WhatWillUseForModel](Matchers.eq(KeystoreKeys.whatWillUseFor))(Matchers.any(), Matchers.any()))
+        .thenReturn(Future.successful(None))
+      when(mockKeyStoreConnector.fetchAndGetFormData[UsedInvestmentReasonBeforeModel](Matchers.eq(KeystoreKeys.usedInvestmentReasonBefore))
+        (Matchers.any(), Matchers.any())).thenReturn(Future.successful(None))
+      when(mockKeyStoreConnector.fetchAndGetFormData[PreviousBeforeDOFCSModel](Matchers.eq(KeystoreKeys.previousBeforeDOFCS))(Matchers.any(),
+        Matchers.any())).thenReturn(Future.successful(None))
+      when(mockKeyStoreConnector.fetchAndGetFormData[NewGeographicalMarketModel](Matchers.eq(KeystoreKeys.newGeographicalMarket))
+        (Matchers.any(), Matchers.any())).thenReturn(Future.successful(None))
+      when(mockKeyStoreConnector.fetchAndGetFormData[NewProductModel](Matchers.eq(KeystoreKeys.newProduct))
+        (Matchers.any(), Matchers.any())).thenReturn(Future.successful(None))
+      when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesSpendingInvestmentModel](Matchers.eq(KeystoreKeys.subsidiariesSpendingInvestment))
+        (Matchers.any(), Matchers.any())).thenReturn(Future.successful(None))
+      when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesNinetyOwnedModel](Matchers.eq(KeystoreKeys.subsidiariesNinetyOwned))(Matchers.any(),
+        Matchers.any())).thenReturn(Future.successful(None))
+      when(mockKeyStoreConnector.fetchAndGetFormData[ContactDetailsModel](Matchers.eq(KeystoreKeys.contactDetails))(Matchers.any(),
+        Matchers.any())).thenReturn(Future.successful(None))
+      when(mockKeyStoreConnector.fetchAndGetFormData[InvestmentGrowModel](Matchers.eq(KeystoreKeys.investmentGrow))(Matchers.any(), Matchers.any()))
+        .thenReturn(Future.successful(None))
+      when(CheckAnswersControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(None))
+
+      showWithSessionAndAuth(CheckAnswersControllerTest.show())(
+        result => {
+          status(result) shouldBe SEE_OTHER
+          redirectLocation(result) shouldBe Some(FrontendAppConfig.subscriptionUrl)
+        }
+      )
+    }
+  }
 
   "Sending an Unauthenticated request with a session to CheckAnswersController" should {
     "return a 302 and redirect to GG login" in {
@@ -247,14 +309,26 @@ class CheckAnswersControllerSpec extends UnitSpec with MockitoSugar with BeforeA
     }
   }
 
+  "Sending a submission to the CheckAnswersController" should {
 
-    "Sending a submission to the CheckAnswersController" should {
-
-      "redirect to the acknowledgement page when authenticated" in {
+      "redirect to the acknowledgement page when authenticated and enrolled" in {
+        when(CheckAnswersControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+          .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
         submitWithSessionAndAuth(CheckAnswersControllerTest.submit)(
           result => {
             status(result) shouldBe SEE_OTHER
             redirectLocation(result) shouldBe Some("/investment-tax-relief/acknowledgement")
+          }
+        )
+      }
+
+      "redirect to the subscription service when authenticated and NOT enrolled" in {
+        when(CheckAnswersControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+          .thenReturn(Future.successful(None))
+        submitWithSessionAndAuth(CheckAnswersControllerTest.submit)(
+          result => {
+            status(result) shouldBe SEE_OTHER
+            redirectLocation(result) shouldBe Some(FrontendAppConfig.subscriptionUrl)
           }
         )
       }

--- a/test/controllers/CheckAnswersControllerSpec.scala
+++ b/test/controllers/CheckAnswersControllerSpec.scala
@@ -62,6 +62,12 @@ class CheckAnswersControllerSpec extends UnitSpec with MockitoSugar with BeforeA
     override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
+  private def mockEnrolledRequest = when(CheckAnswersControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+
+  private def mockNotEnrolledRequest = when(CheckAnswersControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(None))
+
   val yourCompanyNeedModel = YourCompanyNeedModel("")
   val taxpayerReferenceModel = TaxpayerReferenceModel("")
   val registeredAddressModel = RegisteredAddressModel("")
@@ -150,8 +156,7 @@ class CheckAnswersControllerSpec extends UnitSpec with MockitoSugar with BeforeA
         Matchers.any())).thenReturn(Future.successful(Option(contactDetailsModel)))
       when(mockKeyStoreConnector.fetchAndGetFormData[InvestmentGrowModel](Matchers.eq(KeystoreKeys.investmentGrow))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(investmentGrowModel)))
-      when(CheckAnswersControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
 
       showWithSessionAndAuth(CheckAnswersControllerTest.show())(
         result => status(result) shouldBe OK
@@ -205,8 +210,7 @@ class CheckAnswersControllerSpec extends UnitSpec with MockitoSugar with BeforeA
         Matchers.any())).thenReturn(Future.successful(None))
       when(mockKeyStoreConnector.fetchAndGetFormData[InvestmentGrowModel](Matchers.eq(KeystoreKeys.investmentGrow))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(CheckAnswersControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
 
       showWithSessionAndAuth(CheckAnswersControllerTest.show())(
         result => status(result) shouldBe OK
@@ -260,8 +264,7 @@ class CheckAnswersControllerSpec extends UnitSpec with MockitoSugar with BeforeA
         Matchers.any())).thenReturn(Future.successful(None))
       when(mockKeyStoreConnector.fetchAndGetFormData[InvestmentGrowModel](Matchers.eq(KeystoreKeys.investmentGrow))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(CheckAnswersControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
 
       showWithSessionAndAuth(CheckAnswersControllerTest.show())(
         result => {
@@ -323,8 +326,7 @@ class CheckAnswersControllerSpec extends UnitSpec with MockitoSugar with BeforeA
       }
 
       "redirect to the subscription service when authenticated and NOT enrolled" in {
-        when(CheckAnswersControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-          .thenReturn(Future.successful(None))
+        mockNotEnrolledRequest
         submitWithSessionAndAuth(CheckAnswersControllerTest.submit)(
           result => {
             status(result) shouldBe SEE_OTHER

--- a/test/controllers/CommercialSaleControllerSpec.scala
+++ b/test/controllers/CommercialSaleControllerSpec.scala
@@ -48,6 +48,12 @@ class CommercialSaleControllerSpec extends UnitSpec with MockitoSugar with Befor
     override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
+  private def mockEnrolledRequest = when(CommercialSaleControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+
+  private def mockNotEnrolledRequest = when(CommercialSaleControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(None))
+
   val keyStoreSavedCommercialSale = CommercialSaleModel(Constants.StandardRadioButtonYesValue, Some(15),Some(3),Some(1996))
 
   val model = CommercialSaleModel(Constants.StandardRadioButtonYesValue, Some(23),Some(11),Some(1993))
@@ -82,8 +88,7 @@ class CommercialSaleControllerSpec extends UnitSpec with MockitoSugar with Befor
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[CommercialSaleModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedCommercialSale)))
-      when(CommercialSaleControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(CommercialSaleControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -93,8 +98,7 @@ class CommercialSaleControllerSpec extends UnitSpec with MockitoSugar with Befor
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[CommercialSaleModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(CommercialSaleControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(CommercialSaleControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -140,8 +144,7 @@ class CommercialSaleControllerSpec extends UnitSpec with MockitoSugar with Befor
 
   "Sending a NOT enrolled request" should {
     "redirect to the Subscription Service" in {
-      when(CommercialSaleControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       showWithSessionAndAuth(CommercialSaleControllerTest.show())(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -162,8 +165,7 @@ class CommercialSaleControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(Option(savedKIDateconditionMet)))
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.eq(KeystoreKeys.dateOfIncorporation))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedDateOfIncorporation)))
-      when(CommercialSaleControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       submitWithSessionAndAuth(CommercialSaleControllerTest.submit,formInput: _*)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -184,8 +186,7 @@ class CommercialSaleControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(Option(savedKIDateconditionNotMet)))
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.eq(KeystoreKeys.dateOfIncorporation))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedDateOfIncorporation)))
-      when(CommercialSaleControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       submitWithSessionAndAuth(CommercialSaleControllerTest.submit,formInput:_*)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -206,8 +207,7 @@ class CommercialSaleControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(None))
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.eq(KeystoreKeys.dateOfIncorporation))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedDateOfIncorporation)))
-      when(CommercialSaleControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       submitWithSessionAndAuth(CommercialSaleControllerTest.submit,formInput:_*)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -228,8 +228,7 @@ class CommercialSaleControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(Option(savedKIDateconditionMet)))
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.eq(KeystoreKeys.dateOfIncorporation))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedDateOfIncorporation)))
-      when(CommercialSaleControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       submitWithSessionAndAuth(CommercialSaleControllerTest.submit,formInput:_*)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -250,8 +249,7 @@ class CommercialSaleControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(Option(savedKIDateConditionEmpty)))
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.eq(KeystoreKeys.dateOfIncorporation))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedDateOfIncorporation)))
-      when(CommercialSaleControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       submitWithSessionAndAuth(CommercialSaleControllerTest.submit,formInput:_*)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -272,8 +270,7 @@ class CommercialSaleControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(Option(savedKIDateconditionNotMet)))
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.eq(KeystoreKeys.dateOfIncorporation))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedDateOfIncorporation)))
-      when(CommercialSaleControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       submitWithSessionAndAuth(CommercialSaleControllerTest.submit,formInput:_*)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -322,8 +319,7 @@ class CommercialSaleControllerSpec extends UnitSpec with MockitoSugar with Befor
   "Sending a submission to the CommercialSaleController when not enrolled" should {
 
     "redirect to the Subscription Service" in {
-      when(CommercialSaleControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       submitWithSessionAndAuth(CommercialSaleControllerTest.submit)(
         result => {
           status(result) shouldBe SEE_OTHER

--- a/test/controllers/ContactAddressControllerSpec.scala
+++ b/test/controllers/ContactAddressControllerSpec.scala
@@ -19,10 +19,10 @@ package controllers
 import java.net.URLEncoder
 import java.util.UUID
 
-import auth.{MockAuthConnector, MockConfig}
+import auth.{Enrolment, Identifier, MockAuthConnector, MockConfig}
 import builders.SessionBuilder
 import config.{FrontendAppConfig, FrontendAuthConnector}
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.helpers.FakeRequestHelper
 import models._
 import org.mockito.Matchers
@@ -46,6 +46,7 @@ class ContactAddressControllerSpec extends UnitSpec with MockitoSugar with Befor
     override lazy val applicationConfig = FrontendAppConfig
     override lazy val authConnector = MockAuthConnector
     val keyStoreConnector: KeystoreConnector = mockKeyStoreConnector
+    override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
   val model = ContactAddressModel("TF1 3NY")
@@ -71,10 +72,12 @@ class ContactAddressControllerSpec extends UnitSpec with MockitoSugar with Befor
     }
   }
 
-  "Sending a GET request to ContactAddressController when authenticated" should {
+  "Sending a GET request to ContactAddressController when authenticated and enrolled" should {
     "return a 200 OK when something is fetched from keystore" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[ContactAddressModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedContactAddress)))
+      when(ContactAddressControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       showWithSessionAndAuth(ContactAddressControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -83,8 +86,25 @@ class ContactAddressControllerSpec extends UnitSpec with MockitoSugar with Befor
     "provide an empty model and return a 200 when nothing is fetched using keystore" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[ContactAddressModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
+      when(ContactAddressControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       showWithSessionAndAuth(ContactAddressControllerTest.show)(
         result => status(result) shouldBe OK
+      )
+    }
+  }
+
+  "Sending a GET request to ContactAddressController when authenticated and NOT enrolled" should {
+    "redirect to the Subscription Service" in {
+      when(mockKeyStoreConnector.fetchAndGetFormData[ContactAddressModel](Matchers.any())(Matchers.any(), Matchers.any()))
+        .thenReturn(Future.successful(Option(keyStoreSavedContactAddress)))
+      when(ContactAddressControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(None))
+      showWithSessionAndAuth(ContactAddressControllerTest.show)(
+        result => {
+          status(result) shouldBe SEE_OTHER
+          redirectLocation(result) shouldBe Some(FrontendAppConfig.subscriptionUrl)
+        }
       )
     }
   }
@@ -126,9 +146,11 @@ class ContactAddressControllerSpec extends UnitSpec with MockitoSugar with Befor
     }
   }
 
-  "Sending a valid form submit to the ContactAddressController when authenticated" should {
+  "Sending a valid form submit to the ContactAddressController when authenticated and enrolled" should {
     "redirect to the Supporting Documents page" in {
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
+      when(ContactAddressControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       val formInput = "postcode" -> "LE5 5NN"
       submitWithSessionAndAuth(ContactAddressControllerTest.submit,formInput)(
         result => {
@@ -139,12 +161,29 @@ class ContactAddressControllerSpec extends UnitSpec with MockitoSugar with Befor
     }
   }
 
-  "Sending an invalid form submission with validation errors to the ContactAddressController when authenticated" should {
+  "Sending an invalid form submission with validation errors to the ContactAddressController when authenticated and enrolled" should {
     "redirect to itself" in {
+      when(ContactAddressControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       val formInput = "postcode" -> ""
       submitWithSessionAndAuth(ContactAddressControllerTest.submit,formInput)(
         result => {
           status(result) shouldBe BAD_REQUEST
+        }
+      )
+    }
+  }
+
+  "Sending a valid form submit to the ContactAddressController when authenticated and enrolled" should {
+    "redirect to the Subscription Service" in {
+      when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
+      when(ContactAddressControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(None))
+      val formInput = "postcode" -> "LE5 5NN"
+      submitWithSessionAndAuth(ContactAddressControllerTest.submit,formInput)(
+        result => {
+          status(result) shouldBe SEE_OTHER
+          redirectLocation(result) shouldBe Some(FrontendAppConfig.subscriptionUrl)
         }
       )
     }

--- a/test/controllers/ContactDetailsControllerSpec.scala
+++ b/test/controllers/ContactDetailsControllerSpec.scala
@@ -18,9 +18,9 @@ package controllers
 
 import java.net.URLEncoder
 
-import auth.{MockAuthConnector, MockConfig}
+import auth.{Enrolment, Identifier, MockAuthConnector, MockConfig}
 import config.{FrontendAppConfig, FrontendAuthConnector}
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.helpers.FakeRequestHelper
 import models._
 import org.mockito.Matchers
@@ -44,6 +44,7 @@ class ContactDetailsControllerSpec extends UnitSpec with MockitoSugar with Befor
     override lazy val applicationConfig = FrontendAppConfig
     override lazy val authConnector = MockAuthConnector
     val keyStoreConnector: KeystoreConnector = mockKeyStoreConnector
+    override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
   val model = ContactDetailsModel("Frank","The Tank","01384 555678","email@nothingness.com")
@@ -67,11 +68,13 @@ class ContactDetailsControllerSpec extends UnitSpec with MockitoSugar with Befor
     }
   }
 
-  "Sending a GET request to ContactDetailsController when authenticated" should {
+  "Sending a GET request to ContactDetailsController when authenticated and enrolled" should {
     "return a 200 when something is fetched from keystore" in {
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[ContactDetailsModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedContactDetails)))
+      when(ContactDetailsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       showWithSessionAndAuth(ContactDetailsControllerTest.show())(
         result => status(result) shouldBe OK
       )
@@ -81,8 +84,26 @@ class ContactDetailsControllerSpec extends UnitSpec with MockitoSugar with Befor
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[ContactDetailsModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
+      when(ContactDetailsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       showWithSessionAndAuth(ContactDetailsControllerTest.show())(
         result => status(result) shouldBe OK
+      )
+    }
+  }
+
+  "Sending a GET request to ContactDetailsController when authenticated and NOT enrolled" should {
+    "redirect to the Subscription Service" in {
+      when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
+      when(mockKeyStoreConnector.fetchAndGetFormData[ContactDetailsModel](Matchers.any())(Matchers.any(), Matchers.any()))
+        .thenReturn(Future.successful(Option(keyStoreSavedContactDetails)))
+      when(ContactDetailsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(None))
+      showWithSessionAndAuth(ContactDetailsControllerTest.show())(
+        result => {
+          status(result) shouldBe SEE_OTHER
+          redirectLocation(result) shouldBe Some(FrontendAppConfig.subscriptionUrl)
+        }
       )
     }
   }
@@ -124,8 +145,10 @@ class ContactDetailsControllerSpec extends UnitSpec with MockitoSugar with Befor
     }
   }
 
-  "Sending a valid form submit to the ContactDetailsController when authenticated" should {
+  "Sending a valid form submit to the ContactDetailsController when authenticated and enrolled" should {
     "redirect to the Confirm Correspondence Address Controller page" in {
+      when(ContactDetailsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       val formInput = Seq(
         "forename" -> "Hank",
         "surname" -> "The Tank",
@@ -141,8 +164,10 @@ class ContactDetailsControllerSpec extends UnitSpec with MockitoSugar with Befor
     }
   }
 
-  "Sending an invalid form submission with validation errors to the ContactDetailsController when authenticated" should {
+  "Sending an invalid form submission with validation errors to the ContactDetailsController when authenticated and enrolled" should {
     "redirect with a bad request" in {
+      when(ContactDetailsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       val formInput = Seq(
         "forename" -> "Hank",
         "surname" -> "The Tank",
@@ -151,6 +176,25 @@ class ContactDetailsControllerSpec extends UnitSpec with MockitoSugar with Befor
       submitWithSessionAndAuth(ContactDetailsControllerTest.submit,formInput:_*)(
         result => {
           status(result) shouldBe BAD_REQUEST
+        }
+      )
+    }
+  }
+
+  "Sending a valid form submit to the ContactDetailsController when authenticated and NOT enrolled" should {
+    "redirect to the Subscription Service" in {
+      when(ContactDetailsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(None))
+      val formInput = Seq(
+        "forename" -> "Hank",
+        "surname" -> "The Tank",
+        "telephoneNumber" -> "01385 236846",
+        "email" -> "thisiavalidemail@valid.com"
+      )
+      submitWithSessionAndAuth(ContactDetailsControllerTest.submit,formInput:_*)(
+        result => {
+          status(result) shouldBe SEE_OTHER
+          redirectLocation(result) shouldBe Some(FrontendAppConfig.subscriptionUrl)
         }
       )
     }

--- a/test/controllers/ContactDetailsControllerSpec.scala
+++ b/test/controllers/ContactDetailsControllerSpec.scala
@@ -47,6 +47,12 @@ class ContactDetailsControllerSpec extends UnitSpec with MockitoSugar with Befor
     override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
+  private def mockEnrolledRequest = when(ContactDetailsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+
+  private def mockNotEnrolledRequest = when(ContactDetailsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(None))
+
   val model = ContactDetailsModel("Frank","The Tank","01384 555678","email@nothingness.com")
   val emptyModel = ContactDetailsModel("","","","")
   val cacheMap: CacheMap = CacheMap("", Map("" -> Json.toJson(model)))
@@ -73,8 +79,7 @@ class ContactDetailsControllerSpec extends UnitSpec with MockitoSugar with Befor
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[ContactDetailsModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedContactDetails)))
-      when(ContactDetailsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(ContactDetailsControllerTest.show())(
         result => status(result) shouldBe OK
       )
@@ -84,8 +89,7 @@ class ContactDetailsControllerSpec extends UnitSpec with MockitoSugar with Befor
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[ContactDetailsModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(ContactDetailsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(ContactDetailsControllerTest.show())(
         result => status(result) shouldBe OK
       )
@@ -97,8 +101,7 @@ class ContactDetailsControllerSpec extends UnitSpec with MockitoSugar with Befor
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[ContactDetailsModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedContactDetails)))
-      when(ContactDetailsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       showWithSessionAndAuth(ContactDetailsControllerTest.show())(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -147,8 +150,7 @@ class ContactDetailsControllerSpec extends UnitSpec with MockitoSugar with Befor
 
   "Sending a valid form submit to the ContactDetailsController when authenticated and enrolled" should {
     "redirect to the Confirm Correspondence Address Controller page" in {
-      when(ContactDetailsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = Seq(
         "forename" -> "Hank",
         "surname" -> "The Tank",
@@ -166,8 +168,7 @@ class ContactDetailsControllerSpec extends UnitSpec with MockitoSugar with Befor
 
   "Sending an invalid form submission with validation errors to the ContactDetailsController when authenticated and enrolled" should {
     "redirect with a bad request" in {
-      when(ContactDetailsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = Seq(
         "forename" -> "Hank",
         "surname" -> "The Tank",
@@ -183,8 +184,7 @@ class ContactDetailsControllerSpec extends UnitSpec with MockitoSugar with Befor
 
   "Sending a valid form submit to the ContactDetailsController when authenticated and NOT enrolled" should {
     "redirect to the Subscription Service" in {
-      when(ContactDetailsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       val formInput = Seq(
         "forename" -> "Hank",
         "surname" -> "The Tank",

--- a/test/controllers/DateOfIncorporationControllerSpec.scala
+++ b/test/controllers/DateOfIncorporationControllerSpec.scala
@@ -77,6 +77,12 @@ class DateOfIncorporationControllerSpec extends UnitSpec with MockitoSugar with 
     override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
+  private def mockEnrolledRequest = when(DateOfIncorporationControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+
+  private def mockNotEnrolledRequest = when(DateOfIncorporationControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(None))
+
   val dateOfIncorporationAsJson = """{"day": 23,"month": 11, "year": 1993}"""
 
   val model = DateOfIncorporationModel(Some(23), Some(11), Some(1993))
@@ -110,8 +116,7 @@ class DateOfIncorporationControllerSpec extends UnitSpec with MockitoSugar with 
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedDateOfIncorporation)))
-      when(DateOfIncorporationControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(DateOfIncorporationControllerTest.show())(
         result => status(result) shouldBe OK
       )
@@ -121,8 +126,7 @@ class DateOfIncorporationControllerSpec extends UnitSpec with MockitoSugar with 
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(DateOfIncorporationControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(DateOfIncorporationControllerTest.show())(
         result => status(result) shouldBe OK
       )
@@ -134,8 +138,7 @@ class DateOfIncorporationControllerSpec extends UnitSpec with MockitoSugar with 
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedDateOfIncorporation)))
-      when(DateOfIncorporationControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       showWithSessionAndAuth(DateOfIncorporationControllerTest.show())(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -194,8 +197,7 @@ class DateOfIncorporationControllerSpec extends UnitSpec with MockitoSugar with 
         .thenReturn(Future.successful(Option(savedKIData)))
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.eq(KeystoreKeys.dateOfIncorporation))
         (Matchers.any(), Matchers.any())).thenReturn(Future.successful(Option(model)))
-      when(DateOfIncorporationControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
 
       val formInput = Seq(
         "incorporationDay" -> "23",
@@ -213,8 +215,7 @@ class DateOfIncorporationControllerSpec extends UnitSpec with MockitoSugar with 
 
   "Sending an invalid form submission with validation errors to the DateOfIncorporationController when authenticated and enrolled" should {
     "return a bad request" in {
-      when(DateOfIncorporationControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = Seq(
         "incorporationDay" -> "",
         "incorporationMonth" -> "",
@@ -266,8 +267,7 @@ class DateOfIncorporationControllerSpec extends UnitSpec with MockitoSugar with 
 
   "Sending a submission to the DateOfIncorporationController when NOT enrolled" should {
     "redirect to the Subscription Service" in {
-      when(DateOfIncorporationControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       submitWithSessionAndAuth(DateOfIncorporationControllerTest.submit)(
         result => {
           status(result) shouldBe SEE_OTHER

--- a/test/controllers/HadPreviousRFIControllerSpec.scala
+++ b/test/controllers/HadPreviousRFIControllerSpec.scala
@@ -48,6 +48,12 @@ class HadPreviousRFIControllerSpec extends UnitSpec with MockitoSugar with Befor
     override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
+  private def mockEnrolledRequest = when(HadPreviousRFIControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+
+  private def mockNotEnrolledRequest = when(HadPreviousRFIControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(None))
+
   val modelYes = HadPreviousRFIModel("Yes")
   val modelNo = HadPreviousRFIModel("No")
   val emptyModel = HadPreviousRFIModel("")
@@ -74,8 +80,7 @@ class HadPreviousRFIControllerSpec extends UnitSpec with MockitoSugar with Befor
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[HadPreviousRFIModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedHadPreviousRFI)))
-      when(HadPreviousRFIControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(HadPreviousRFIControllerTest.show())(
         result => status(result) shouldBe OK
       )
@@ -96,8 +101,7 @@ class HadPreviousRFIControllerSpec extends UnitSpec with MockitoSugar with Befor
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[HadPreviousRFIModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedHadPreviousRFI)))
-      when(HadPreviousRFIControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       showWithSessionAndAuth(HadPreviousRFIControllerTest.show())(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -147,8 +151,7 @@ class HadPreviousRFIControllerSpec extends UnitSpec with MockitoSugar with Befor
   "Sending a valid 'Yes' form submit to the HadPreviousRFIController when authenticated and enrolled" should {
     "redirect to itself" in {
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
-      when(HadPreviousRFIControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "hadPreviousRFI" -> Constants.StandardRadioButtonYesValue
       submitWithSessionAndAuth(HadPreviousRFIControllerTest.submit,formInput)(
         result => {
@@ -162,8 +165,7 @@ class HadPreviousRFIControllerSpec extends UnitSpec with MockitoSugar with Befor
   "Sending a valid 'No' form submit to the HadPreviousRFIController when authenticated and enrolled" should {
     "redirect to the commercial sale page" in {
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
-      when(HadPreviousRFIControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "hadPreviousRFI" -> Constants.StandardRadioButtonNoValue
       submitWithSessionAndAuth(HadPreviousRFIControllerTest.submit,formInput)(
         result => {
@@ -176,8 +178,7 @@ class HadPreviousRFIControllerSpec extends UnitSpec with MockitoSugar with Befor
 
   "Sending an invalid form submission with validation errors to the HadPreviousRFIController when authenticated and enrolled" should {
     "redirect to itself" in {
-      when(HadPreviousRFIControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "hadPreviousRFI" -> ""
       submitWithSessionAndAuth(HadPreviousRFIControllerTest.submit,formInput)(
         result => {
@@ -226,8 +227,7 @@ class HadPreviousRFIControllerSpec extends UnitSpec with MockitoSugar with Befor
 
   "Sending a submission to the HadPreviousRFIController when NOT enrolled" should {
     "redirect to the Subscription Service" in {
-      when(HadPreviousRFIControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       submitWithSessionAndAuth(HadPreviousRFIControllerTest.submit)(
         result => {
           status(result) shouldBe SEE_OTHER

--- a/test/controllers/HowToApplyControllerSpec.scala
+++ b/test/controllers/HowToApplyControllerSpec.scala
@@ -19,11 +19,13 @@ package controllers
 import java.net.URLEncoder
 import java.util.UUID
 
-import auth.{MockAuthConnector, MockConfig}
+import auth.{Enrolment, Identifier, MockAuthConnector, MockConfig}
 import builders.SessionBuilder
 import config.{FrontendAppConfig, FrontendAuthConnector}
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.helpers.FakeRequestHelper
+import org.mockito.Matchers
+import org.mockito.Mockito._
 import play.api.mvc.{AnyContentAsFormUrlEncoded, Result}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -41,6 +43,7 @@ class HowToApplyControllerSpec extends UnitSpec with MockitoSugar with WithFakeA
   object HowToApplyControllerTest extends HowToApplyController {
     override lazy val applicationConfig = FrontendAppConfig
     override lazy val authConnector = MockAuthConnector
+    override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
   "HowToApplyController" should {
@@ -49,10 +52,25 @@ class HowToApplyControllerSpec extends UnitSpec with MockitoSugar with WithFakeA
     }
   }
 
-  "Sending a GET request to HowToApplyController when authenticated" should {
+  "Sending a GET request to HowToApplyController when authenticated and enrolled" should {
     "return a 200" in {
+      when(HowToApplyControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       showWithSessionAndAuth(HowToApplyControllerTest.show())(
         result => status(result) shouldBe OK
+      )
+    }
+  }
+
+  "Sending a GET request to HowToApplyController when authenticated and NOT enrolled" should {
+    "return a 200" in {
+      when(HowToApplyControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(None))
+      showWithSessionAndAuth(HowToApplyControllerTest.show())(
+        result => {
+          status(result) shouldBe SEE_OTHER
+          redirectLocation(result) shouldBe Some(FrontendAppConfig.subscriptionUrl)
+        }
       )
     }
   }
@@ -95,9 +113,10 @@ class HowToApplyControllerSpec extends UnitSpec with MockitoSugar with WithFakeA
   }
 
 
-  "Posting to the HowToApplyController" should {
+  "Posting to the HowToApplyController when authenticated and enrolled" should {
     "redirect to 'What does your company need' page" in {
-
+      when(HowToApplyControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       val request = FakeRequest().withFormUrlEncodedBody()
 
       submitWithSessionAndAuth(HowToApplyControllerTest.submit())(
@@ -140,6 +159,21 @@ class HowToApplyControllerSpec extends UnitSpec with MockitoSugar with WithFakeA
         result => {
           status(result) shouldBe SEE_OTHER
           redirectLocation(result) shouldBe Some(routes.TimeoutController.timeout().url)
+        }
+      )
+    }
+  }
+
+  "Posting to the HowToApplyController when authenticated and NOT enrolled" should {
+    "redirect to the Subscription Service" in {
+      when(HowToApplyControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(None))
+      val request = FakeRequest().withFormUrlEncodedBody()
+
+      submitWithSessionAndAuth(HowToApplyControllerTest.submit())(
+        result => {
+          status(result) shouldBe SEE_OTHER
+          redirectLocation(result) shouldBe Some(FrontendAppConfig.subscriptionUrl)
         }
       )
     }

--- a/test/controllers/HowToApplyControllerSpec.scala
+++ b/test/controllers/HowToApplyControllerSpec.scala
@@ -46,6 +46,12 @@ class HowToApplyControllerSpec extends UnitSpec with MockitoSugar with WithFakeA
     override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
+  private def mockEnrolledRequest = when(HowToApplyControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+
+  private def mockNotEnrolledRequest = when(HowToApplyControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(None))
+
   "HowToApplyController" should {
     "use the correct auth connector" in {
       HowToApplyController.authConnector shouldBe FrontendAuthConnector
@@ -54,8 +60,7 @@ class HowToApplyControllerSpec extends UnitSpec with MockitoSugar with WithFakeA
 
   "Sending a GET request to HowToApplyController when authenticated and enrolled" should {
     "return a 200" in {
-      when(HowToApplyControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(HowToApplyControllerTest.show())(
         result => status(result) shouldBe OK
       )
@@ -64,8 +69,7 @@ class HowToApplyControllerSpec extends UnitSpec with MockitoSugar with WithFakeA
 
   "Sending a GET request to HowToApplyController when authenticated and NOT enrolled" should {
     "return a 200" in {
-      when(HowToApplyControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       showWithSessionAndAuth(HowToApplyControllerTest.show())(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -115,8 +119,7 @@ class HowToApplyControllerSpec extends UnitSpec with MockitoSugar with WithFakeA
 
   "Posting to the HowToApplyController when authenticated and enrolled" should {
     "redirect to 'What does your company need' page" in {
-      when(HowToApplyControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val request = FakeRequest().withFormUrlEncodedBody()
 
       submitWithSessionAndAuth(HowToApplyControllerTest.submit())(
@@ -166,8 +169,7 @@ class HowToApplyControllerSpec extends UnitSpec with MockitoSugar with WithFakeA
 
   "Posting to the HowToApplyController when authenticated and NOT enrolled" should {
     "redirect to the Subscription Service" in {
-      when(HowToApplyControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       val request = FakeRequest().withFormUrlEncodedBody()
 
       submitWithSessionAndAuth(HowToApplyControllerTest.submit())(

--- a/test/controllers/IneligibleForKIControllerSpec.scala
+++ b/test/controllers/IneligibleForKIControllerSpec.scala
@@ -48,6 +48,12 @@ class IneligibleForKIControllerSpec extends UnitSpec with MockitoSugar with Befo
     override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
+  private def mockEnrolledRequest = when(IneligibleForKIControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+
+  private def mockNotEnrolledRequest = when(IneligibleForKIControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(None))
+
   override def beforeEach() {
     reset(mockKeyStoreConnector)
   }
@@ -68,8 +74,7 @@ class IneligibleForKIControllerSpec extends UnitSpec with MockitoSugar with Befo
       when(mockKeyStoreConnector.fetchAndGetFormData[String]
         (Matchers.eq(KeystoreKeys.backLinkIneligibleForKI))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(IneligibleForKIControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(IneligibleForKIControllerTest.show())(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -84,8 +89,7 @@ class IneligibleForKIControllerSpec extends UnitSpec with MockitoSugar with Befo
       when(mockKeyStoreConnector.fetchAndGetFormData[String]
         (Matchers.eq(KeystoreKeys.backLinkIneligibleForKI))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.OperatingCostsController.show().toString())))
-      when(IneligibleForKIControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(IneligibleForKIControllerTest.show())(
         result => status(result) shouldBe OK
       )
@@ -97,8 +101,7 @@ class IneligibleForKIControllerSpec extends UnitSpec with MockitoSugar with Befo
       when(mockKeyStoreConnector.fetchAndGetFormData[String]
         (Matchers.eq(KeystoreKeys.backLinkIneligibleForKI))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.OperatingCostsController.show().toString())))
-      when(IneligibleForKIControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       showWithSessionAndAuth(IneligibleForKIControllerTest.show())(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -152,8 +155,7 @@ class IneligibleForKIControllerSpec extends UnitSpec with MockitoSugar with Befo
       when(mockKeyStoreConnector.fetchAndGetFormData[String]
         (Matchers.eq(KeystoreKeys.backLinkIneligibleForKI))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.OperatingCostsController.show().toString())))
-      when(IneligibleForKIControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       submitWithSessionAndAuth(IneligibleForKIControllerTest.submit)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -201,8 +203,7 @@ class IneligibleForKIControllerSpec extends UnitSpec with MockitoSugar with Befo
 
   "Sending a submission to the IneligibleForKIController when not enrolled" should {
     "redirect to the Subscription Service" in {
-      when(IneligibleForKIControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       submitWithSessionAndAuth(IneligibleForKIControllerTest.submit)(
         result => {
           status(result) shouldBe SEE_OTHER

--- a/test/controllers/InvestmentGrowControllerSpec.scala
+++ b/test/controllers/InvestmentGrowControllerSpec.scala
@@ -48,6 +48,12 @@ class InvestmentGrowControllerSpec extends UnitSpec with MockitoSugar with Befor
     override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
+  private def mockEnrolledRequest = when(InvestmentGrowControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+
+  private def mockNotEnrolledRequest = when(InvestmentGrowControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(None))
+
   val model = InvestmentGrowModel("some text")
   val emptyModel = InvestmentGrowModel("")
   val cacheMap: CacheMap = CacheMap("", Map("" -> Json.toJson(model)))
@@ -76,8 +82,7 @@ class InvestmentGrowControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(Option(keyStoreSavedInvestmentGrow)))
       when(mockKeyStoreConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkInvestmentGrow))(Matchers.any(), Matchers.any()))
           .thenReturn(Future.successful(Option(routes.SubsidiariesNinetyOwnedController.show().toString())))
-      when(InvestmentGrowControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(InvestmentGrowControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -89,8 +94,7 @@ class InvestmentGrowControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(None))
       when(mockKeyStoreConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkInvestmentGrow))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.SubsidiariesNinetyOwnedController.show().toString())))
-      when(InvestmentGrowControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(InvestmentGrowControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -101,8 +105,7 @@ class InvestmentGrowControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(None))
       when(mockKeyStoreConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkInvestmentGrow))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(InvestmentGrowControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(InvestmentGrowControllerTest.show)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -119,8 +122,7 @@ class InvestmentGrowControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(Option(keyStoreSavedInvestmentGrow)))
       when(mockKeyStoreConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkInvestmentGrow))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.SubsidiariesNinetyOwnedController.show().toString())))
-      when(InvestmentGrowControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       showWithSessionAndAuth(InvestmentGrowControllerTest.show)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -170,8 +172,7 @@ class InvestmentGrowControllerSpec extends UnitSpec with MockitoSugar with Befor
 
   "Sending a valid form submit to the InvestmentGrowController when authenticated and enrolled" should {
     "redirect to Contact Details Controller" in {
-      when(InvestmentGrowControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "investmentGrowDesc" -> "some text so it's valid"
       submitWithSessionAndAuth(InvestmentGrowControllerTest.submit,formInput)(
         result => {
@@ -186,8 +187,7 @@ class InvestmentGrowControllerSpec extends UnitSpec with MockitoSugar with Befor
     "redirect to WhatWillUseFor page" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkInvestmentGrow))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(InvestmentGrowControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "investmentGrowDesc" -> ""
       submitWithSessionAndAuth(InvestmentGrowControllerTest.submit,formInput)(
         result => {
@@ -204,8 +204,7 @@ class InvestmentGrowControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(Option(routes.SubsidiariesNinetyOwnedController.show().toString())))
       when(mockKeyStoreConnector.fetchAndGetFormData[InvestmentGrowModel](Matchers.eq(KeystoreKeys.investmentGrow))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Some(keyStoreSavedInvestmentGrow)))
-      when(InvestmentGrowControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "investmentGrowDesc" -> ""
       submitWithSessionAndAuth(InvestmentGrowControllerTest.submit,formInput)(
         result => {
@@ -253,8 +252,7 @@ class InvestmentGrowControllerSpec extends UnitSpec with MockitoSugar with Befor
 
   "Sending a submission to the InvestmentGrowController when NOT enrolled" should {
     "redirect to the Subscription Service" in {
-      when(InvestmentGrowControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       submitWithSessionAndAuth(InvestmentGrowControllerTest.submit)(
         result => {
           status(result) shouldBe SEE_OTHER

--- a/test/controllers/IsKnowledgeIntensiveControllerSpec.scala
+++ b/test/controllers/IsKnowledgeIntensiveControllerSpec.scala
@@ -48,6 +48,12 @@ class IsKnowledgeIntensiveControllerSpec extends UnitSpec with MockitoSugar with
     override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
+  private def mockEnrolledRequest = when(IsKnowledgeIntensiveControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+
+  private def mockNotEnrolledRequest = when(IsKnowledgeIntensiveControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(None))
+
   val modelYes = IsKnowledgeIntensiveModel(Constants.StandardRadioButtonYesValue)
   val modelNo = IsKnowledgeIntensiveModel(Constants.StandardRadioButtonNoValue)
   val emptyModel = IsKnowledgeIntensiveModel("")
@@ -79,8 +85,7 @@ class IsKnowledgeIntensiveControllerSpec extends UnitSpec with MockitoSugar with
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[IsKnowledgeIntensiveModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedIsKnowledgeIntensive)))
-      when(IsKnowledgeIntensiveControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(IsKnowledgeIntensiveControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -90,8 +95,7 @@ class IsKnowledgeIntensiveControllerSpec extends UnitSpec with MockitoSugar with
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[IsKnowledgeIntensiveModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(IsKnowledgeIntensiveControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(IsKnowledgeIntensiveControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -103,8 +107,7 @@ class IsKnowledgeIntensiveControllerSpec extends UnitSpec with MockitoSugar with
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[IsKnowledgeIntensiveModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedIsKnowledgeIntensive)))
-      when(IsKnowledgeIntensiveControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       showWithSessionAndAuth(IsKnowledgeIntensiveControllerTest.show)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -156,8 +159,7 @@ class IsKnowledgeIntensiveControllerSpec extends UnitSpec with MockitoSugar with
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[KiProcessingModel](Matchers.eq(KeystoreKeys.kiProcessingModel))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(updatedKIModel)))
-      when(IsKnowledgeIntensiveControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "isKnowledgeIntensive" -> Constants.StandardRadioButtonYesValue
       submitWithSessionAndAuth(IsKnowledgeIntensiveControllerTest.submit,formInput)(
         result => {
@@ -173,8 +175,7 @@ class IsKnowledgeIntensiveControllerSpec extends UnitSpec with MockitoSugar with
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[KiProcessingModel](Matchers.eq(KeystoreKeys.kiProcessingModel))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(missingDateKIModel)))
-      when(IsKnowledgeIntensiveControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "isKnowledgeIntensive" -> Constants.StandardRadioButtonYesValue
       submitWithSessionAndAuth(IsKnowledgeIntensiveControllerTest.submit,formInput)(
         result => {
@@ -190,8 +191,7 @@ class IsKnowledgeIntensiveControllerSpec extends UnitSpec with MockitoSugar with
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[KiProcessingModel](Matchers.eq(KeystoreKeys.kiProcessingModel))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(falseKIModel)))
-      when(IsKnowledgeIntensiveControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "isKnowledgeIntensive" -> Constants.StandardRadioButtonNoValue
       submitWithSessionAndAuth(IsKnowledgeIntensiveControllerTest.submit,formInput)(
         result => {
@@ -207,8 +207,7 @@ class IsKnowledgeIntensiveControllerSpec extends UnitSpec with MockitoSugar with
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[KiProcessingModel](Matchers.eq(KeystoreKeys.kiProcessingModel))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(IsKnowledgeIntensiveControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "isKnowledgeIntensive" -> Constants.StandardRadioButtonNoValue
       submitWithSessionAndAuth(IsKnowledgeIntensiveControllerTest.submit,formInput)(
         result => {
@@ -224,8 +223,7 @@ class IsKnowledgeIntensiveControllerSpec extends UnitSpec with MockitoSugar with
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[KiProcessingModel](Matchers.eq(KeystoreKeys.kiProcessingModel))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(updatedKIModel)))
-      when(IsKnowledgeIntensiveControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "isKnowledgeIntensive" -> Constants.StandardRadioButtonNoValue
       submitWithSessionAndAuth(IsKnowledgeIntensiveControllerTest.submit,formInput)(
         result => {
@@ -238,8 +236,7 @@ class IsKnowledgeIntensiveControllerSpec extends UnitSpec with MockitoSugar with
   
   "Sending an invalid form submission with validation errors to the IsKnowledgeIntensiveController when authenticated and enrolled" should {
     "redirect to itself" in {
-      when(IsKnowledgeIntensiveControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "isKnowledgeIntensive" -> ""
       submitWithSessionAndAuth(IsKnowledgeIntensiveControllerTest.submit,formInput)(
         result => {
@@ -287,8 +284,7 @@ class IsKnowledgeIntensiveControllerSpec extends UnitSpec with MockitoSugar with
 
   "Sending a submission to the IsKnowledgeIntensiveController when NOT enrolled" should {
     "redirect to the Subscription Service" in {
-      when(IsKnowledgeIntensiveControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       submitWithSessionAndAuth(IsKnowledgeIntensiveControllerTest.submit)(
         result => {
           status(result) shouldBe SEE_OTHER

--- a/test/controllers/LifetimeAllowanceExceededControllerSpec.scala
+++ b/test/controllers/LifetimeAllowanceExceededControllerSpec.scala
@@ -47,6 +47,12 @@ class LifetimeAllowanceExceededControllerSpec extends UnitSpec with MockitoSugar
     override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
+  private def mockEnrolledRequest = when(LifetimeAllowanceExceededControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+
+  private def mockNotEnrolledRequest = when(LifetimeAllowanceExceededControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(None))
+
   "LifetimeAllowanceExceededController" should {
     "use the correct keystore connector" in {
       LifetimeAllowanceExceededController.keyStoreConnector shouldBe KeystoreConnector
@@ -58,8 +64,7 @@ class LifetimeAllowanceExceededControllerSpec extends UnitSpec with MockitoSugar
 
   "Sending a GET request to LifetimeAllowanceExceededController when authenticated and enrolled" should {
     "return a 200" in {
-      when(LifetimeAllowanceExceededControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(LifetimeAllowanceExceededControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -68,8 +73,7 @@ class LifetimeAllowanceExceededControllerSpec extends UnitSpec with MockitoSugar
 
   "Sending a GET request to LifetimeAllowanceExceededController when authenticated and NOT enrolled" should {
     "redirect to the Subscription Service" in {
-      when(LifetimeAllowanceExceededControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       showWithSessionAndAuth(LifetimeAllowanceExceededControllerTest.show)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -118,8 +122,7 @@ class LifetimeAllowanceExceededControllerSpec extends UnitSpec with MockitoSugar
 
   "Posting to the LifetimeAllowanceExceededController when authenticated and enrolled" should {
     "redirect to 'Proposed investment' page" in {
-      when(LifetimeAllowanceExceededControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       submitWithSessionAndAuth(LifetimeAllowanceExceededControllerTest.submit)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -167,8 +170,7 @@ class LifetimeAllowanceExceededControllerSpec extends UnitSpec with MockitoSugar
 
   "Sending a submission to the LifetimeAllowanceExceededController when NOT enrolled" should {
     "redirect to the Subscription Service" in {
-      when(LifetimeAllowanceExceededControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       submitWithSessionAndAuth(LifetimeAllowanceExceededControllerTest.submit)(
         result => {
           status(result) shouldBe SEE_OTHER

--- a/test/controllers/LifetimeAllowanceExceededControllerSpec.scala
+++ b/test/controllers/LifetimeAllowanceExceededControllerSpec.scala
@@ -18,15 +18,19 @@ package controllers
 
 import java.net.URLEncoder
 
-import auth.{MockAuthConnector, MockConfig}
+import auth.{Enrolment, Identifier, MockAuthConnector, MockConfig}
 import config.{FrontendAppConfig, FrontendAuthConnector}
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.helpers.FakeRequestHelper
+import org.mockito.Matchers
+import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.play.http.HeaderCarrier
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+
+import scala.concurrent.Future
 
 
 class LifetimeAllowanceExceededControllerSpec extends UnitSpec with MockitoSugar with WithFakeApplication with FakeRequestHelper{
@@ -40,6 +44,7 @@ class LifetimeAllowanceExceededControllerSpec extends UnitSpec with MockitoSugar
     override lazy val applicationConfig = FrontendAppConfig
     override lazy val authConnector = MockAuthConnector
     val keyStoreConnector: KeystoreConnector = mockKeyStoreConnector
+    override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
   "LifetimeAllowanceExceededController" should {
@@ -51,10 +56,25 @@ class LifetimeAllowanceExceededControllerSpec extends UnitSpec with MockitoSugar
     }
   }
 
-  "Sending a GET request to LifetimeAllowanceExceededController when authenticated" should {
+  "Sending a GET request to LifetimeAllowanceExceededController when authenticated and enrolled" should {
     "return a 200" in {
+      when(LifetimeAllowanceExceededControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       showWithSessionAndAuth(LifetimeAllowanceExceededControllerTest.show)(
         result => status(result) shouldBe OK
+      )
+    }
+  }
+
+  "Sending a GET request to LifetimeAllowanceExceededController when authenticated and NOT enrolled" should {
+    "redirect to the Subscription Service" in {
+      when(LifetimeAllowanceExceededControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(None))
+      showWithSessionAndAuth(LifetimeAllowanceExceededControllerTest.show)(
+        result => {
+          status(result) shouldBe SEE_OTHER
+          redirectLocation(result) shouldBe Some(FrontendAppConfig.subscriptionUrl)
+        }
       )
     }
   }
@@ -96,9 +116,10 @@ class LifetimeAllowanceExceededControllerSpec extends UnitSpec with MockitoSugar
     }
   }
 
-  "Posting to the LifetimeAllowanceExceededController when authenticated" should {
+  "Posting to the LifetimeAllowanceExceededController when authenticated and enrolled" should {
     "redirect to 'Proposed investment' page" in {
-
+      when(LifetimeAllowanceExceededControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       submitWithSessionAndAuth(LifetimeAllowanceExceededControllerTest.submit)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -139,6 +160,19 @@ class LifetimeAllowanceExceededControllerSpec extends UnitSpec with MockitoSugar
         result => {
           status(result) shouldBe SEE_OTHER
           redirectLocation(result) shouldBe Some(routes.TimeoutController.timeout().url)
+        }
+      )
+    }
+  }
+
+  "Sending a submission to the LifetimeAllowanceExceededController when NOT enrolled" should {
+    "redirect to the Subscription Service" in {
+      when(LifetimeAllowanceExceededControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(None))
+      submitWithSessionAndAuth(LifetimeAllowanceExceededControllerTest.submit)(
+        result => {
+          status(result) shouldBe SEE_OTHER
+          redirectLocation(result) shouldBe Some(FrontendAppConfig.subscriptionUrl)
         }
       )
     }

--- a/test/controllers/NatureOfBusinessControllerSpec.scala
+++ b/test/controllers/NatureOfBusinessControllerSpec.scala
@@ -51,6 +51,12 @@ class NatureOfBusinessControllerSpec extends UnitSpec with MockitoSugar with Bef
     override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
+  private def mockEnrolledRequest = when(NatureOfBusinessControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+
+  private def mockNotEnrolledRequest = when(NatureOfBusinessControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(None))
+
   val natureOfBusinessAsJson = """{"day": 23,"month": 11, "year": 1993}"""
 
   val model = NatureOfBusinessModel("some text")
@@ -78,8 +84,7 @@ class NatureOfBusinessControllerSpec extends UnitSpec with MockitoSugar with Bef
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[NatureOfBusinessModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedNatureOfBusiness)))
-      when(NatureOfBusinessControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(NatureOfBusinessControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -89,8 +94,7 @@ class NatureOfBusinessControllerSpec extends UnitSpec with MockitoSugar with Bef
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[NatureOfBusinessModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(NatureOfBusinessControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(NatureOfBusinessControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -102,8 +106,7 @@ class NatureOfBusinessControllerSpec extends UnitSpec with MockitoSugar with Bef
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[NatureOfBusinessModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedNatureOfBusiness)))
-      when(NatureOfBusinessControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       showWithSessionAndAuth(NatureOfBusinessControllerTest.show)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -152,8 +155,7 @@ class NatureOfBusinessControllerSpec extends UnitSpec with MockitoSugar with Bef
 
   "Sending a valid form submit to the NatureOfBusinessController when auththenticated and enrolled" should {
     "redirect to the commercial sale page" in {
-      when(NatureOfBusinessControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "natureofbusiness" -> "some text so it's valid"
 
       submitWithSessionAndAuth(NatureOfBusinessControllerTest.submit,formInput)(
@@ -167,8 +169,7 @@ class NatureOfBusinessControllerSpec extends UnitSpec with MockitoSugar with Bef
 
   "Sending an invalid form submission with validation errors to the NatureOfBusinessController when authenticated and enrolled" should {
     "redirect to itself" in {
-      when(NatureOfBusinessControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "natureofbusiness" -> ""
 
       submitWithSessionAndAuth(NatureOfBusinessControllerTest.submit,formInput)(
@@ -218,8 +219,7 @@ class NatureOfBusinessControllerSpec extends UnitSpec with MockitoSugar with Bef
 
   "Sending a submission to the NatureOfBusinessController when NOT enrolled" should {
     "redirect to the Subscription Service" in {
-      when(NatureOfBusinessControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       submitWithSessionAndAuth(NatureOfBusinessControllerTest.submit)(
         result => {
           status(result) shouldBe SEE_OTHER

--- a/test/controllers/NewGeographicalMarketControllerSpec.scala
+++ b/test/controllers/NewGeographicalMarketControllerSpec.scala
@@ -48,6 +48,12 @@ class NewGeographicalMarketControllerSpec extends UnitSpec with MockitoSugar wit
     override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
+  private def mockEnrolledRequest = when(NewGeographicalMarketControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+
+  private def mockNotEnrolledRequest = when(NewGeographicalMarketControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(None))
+
   val modelYes = NewGeographicalMarketModel(Constants.StandardRadioButtonYesValue)
   val modelNo = NewGeographicalMarketModel(Constants.StandardRadioButtonNoValue)
   val emptyModel = NewGeographicalMarketModel("")
@@ -75,8 +81,7 @@ class NewGeographicalMarketControllerSpec extends UnitSpec with MockitoSugar wit
         .thenReturn(Future.successful(Option(keyStoreSavedNewGeographicalMarket)))
       when(mockKeyStoreConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkNewGeoMarket))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.WhatWillUseForController.show().toString())))
-      when(NewGeographicalMarketControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(NewGeographicalMarketControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -87,8 +92,7 @@ class NewGeographicalMarketControllerSpec extends UnitSpec with MockitoSugar wit
         .thenReturn(Future.successful(None))
       when(mockKeyStoreConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkNewGeoMarket))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.WhatWillUseForController.show().toString())))
-      when(NewGeographicalMarketControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(NewGeographicalMarketControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -99,8 +103,7 @@ class NewGeographicalMarketControllerSpec extends UnitSpec with MockitoSugar wit
         .thenReturn(Future.successful(None))
       when(mockKeyStoreConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkNewGeoMarket))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(NewGeographicalMarketControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(NewGeographicalMarketControllerTest.show)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -116,8 +119,7 @@ class NewGeographicalMarketControllerSpec extends UnitSpec with MockitoSugar wit
         .thenReturn(Future.successful(Option(keyStoreSavedNewGeographicalMarket)))
       when(mockKeyStoreConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkNewGeoMarket))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.WhatWillUseForController.show().toString())))
-      when(NewGeographicalMarketControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       showWithSessionAndAuth(NewGeographicalMarketControllerTest.show)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -167,8 +169,7 @@ class NewGeographicalMarketControllerSpec extends UnitSpec with MockitoSugar wit
   "Sending a valid 'Yes' form submit to the NewGeographicalMarketController when authenticated and enrolled" should {
     "redirect to the subsidiaries page" in {
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
-      when(NewGeographicalMarketControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "isNewGeographicalMarket" -> Constants.StandardRadioButtonYesValue
       submitWithSessionAndAuth(NewGeographicalMarketControllerTest.submit, formInput)(
         result => {
@@ -182,8 +183,7 @@ class NewGeographicalMarketControllerSpec extends UnitSpec with MockitoSugar wit
   "Sending a valid 'No' form submit to the NewGeographicalMarketController when authenticated and enrolled" should {
     "redirect the ten year plan page" in {
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
-      when(NewGeographicalMarketControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "isNewGeographicalMarket" -> Constants.StandardRadioButtonNoValue
       submitWithSessionAndAuth(NewGeographicalMarketControllerTest.submit, formInput)(
         result => {
@@ -198,8 +198,7 @@ class NewGeographicalMarketControllerSpec extends UnitSpec with MockitoSugar wit
     "redirect to WhatWillUseFor page" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkNewGeoMarket))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(NewGeographicalMarketControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "isNewGeographicalMarket" -> ""
       submitWithSessionAndAuth(NewGeographicalMarketControllerTest.submit, formInput)(
         result => {
@@ -214,8 +213,7 @@ class NewGeographicalMarketControllerSpec extends UnitSpec with MockitoSugar wit
     "redirect to itself with errors" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkNewGeoMarket))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.WhatWillUseForController.show().toString())))
-      when(NewGeographicalMarketControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "isNewGeographicalMarket" -> ""
       submitWithSessionAndAuth(NewGeographicalMarketControllerTest.submit, formInput)(
         result => {
@@ -263,8 +261,7 @@ class NewGeographicalMarketControllerSpec extends UnitSpec with MockitoSugar wit
 
   "Sending a submission to the NewGeographicalMarketController when NOT enrolled" should {
     "redirect to the Timeout page when session has timed out" in {
-      when(NewGeographicalMarketControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       submitWithSessionAndAuth(NewGeographicalMarketControllerTest.submit)(
         result => {
           status(result) shouldBe SEE_OTHER

--- a/test/controllers/NewGeographicalMarketControllerSpec.scala
+++ b/test/controllers/NewGeographicalMarketControllerSpec.scala
@@ -18,10 +18,10 @@ package controllers
 
 import java.net.URLEncoder
 
-import auth.{MockAuthConnector, MockConfig}
+import auth.{Enrolment, Identifier, MockAuthConnector, MockConfig}
 import common.{Constants, KeystoreKeys}
 import config.{FrontendAppConfig, FrontendAuthConnector}
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.helpers.FakeRequestHelper
 import models.NewGeographicalMarketModel
 import org.mockito.Matchers
@@ -45,6 +45,7 @@ class NewGeographicalMarketControllerSpec extends UnitSpec with MockitoSugar wit
     override lazy val applicationConfig = FrontendAppConfig
     override lazy val authConnector = MockAuthConnector
     val keyStoreConnector: KeystoreConnector = mockKeyStoreConnector
+    override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
   val modelYes = NewGeographicalMarketModel(Constants.StandardRadioButtonYesValue)
@@ -68,36 +69,59 @@ class NewGeographicalMarketControllerSpec extends UnitSpec with MockitoSugar wit
     }
   }
 
-  "Sending a GET request to NewGeographicalMarketController when authenticated" should {
+  "Sending a GET request to NewGeographicalMarketController when authenticated and enrolled" should {
     "return a 200 when something is fetched from keystore" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[NewGeographicalMarketModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedNewGeographicalMarket)))
       when(mockKeyStoreConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkNewGeoMarket))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.WhatWillUseForController.show().toString())))
+      when(NewGeographicalMarketControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       showWithSessionAndAuth(NewGeographicalMarketControllerTest.show)(
         result => status(result) shouldBe OK
       )
     }
 
-    "provide an empty model and return a 200 when nothing is fetched using keystore when authenticated"  in {
+    "provide an empty model and return a 200 when nothing is fetched using keystore when authenticated and enrolled"  in {
       when(mockKeyStoreConnector.fetchAndGetFormData[NewGeographicalMarketModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
       when(mockKeyStoreConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkNewGeoMarket))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.WhatWillUseForController.show().toString())))
+      when(NewGeographicalMarketControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       showWithSessionAndAuth(NewGeographicalMarketControllerTest.show)(
         result => status(result) shouldBe OK
       )
     }
 
-    "provide an empty model and return a 300 when no back link is fetched using keystore when authenticated" in {
+    "provide an empty model and return a 300 when no back link is fetched using keystore when authenticated and enrolled" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[NewGeographicalMarketModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
       when(mockKeyStoreConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkNewGeoMarket))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
+      when(NewGeographicalMarketControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       showWithSessionAndAuth(NewGeographicalMarketControllerTest.show)(
         result => {
           status(result) shouldBe SEE_OTHER
           redirectLocation(result) shouldBe Some("/investment-tax-relief/investment-purpose")
+        }
+      )
+    }
+  }
+
+  "Sending a GET request to NewGeographicalMarketController when authenticated and NOT enrolled" should {
+    "redirect to the Subscription Service" in {
+      when(mockKeyStoreConnector.fetchAndGetFormData[NewGeographicalMarketModel](Matchers.any())(Matchers.any(), Matchers.any()))
+        .thenReturn(Future.successful(Option(keyStoreSavedNewGeographicalMarket)))
+      when(mockKeyStoreConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkNewGeoMarket))(Matchers.any(), Matchers.any()))
+        .thenReturn(Future.successful(Option(routes.WhatWillUseForController.show().toString())))
+      when(NewGeographicalMarketControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(None))
+      showWithSessionAndAuth(NewGeographicalMarketControllerTest.show)(
+        result => {
+          status(result) shouldBe SEE_OTHER
+          redirectLocation(result) shouldBe Some(FrontendAppConfig.subscriptionUrl)
         }
       )
     }
@@ -140,9 +164,11 @@ class NewGeographicalMarketControllerSpec extends UnitSpec with MockitoSugar wit
     }
   }
 
-  "Sending a valid 'Yes' form submit to the NewGeographicalMarketController when authenticated" should {
+  "Sending a valid 'Yes' form submit to the NewGeographicalMarketController when authenticated and enrolled" should {
     "redirect to the subsidiaries page" in {
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
+      when(NewGeographicalMarketControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       val formInput = "isNewGeographicalMarket" -> Constants.StandardRadioButtonYesValue
       submitWithSessionAndAuth(NewGeographicalMarketControllerTest.submit, formInput)(
         result => {
@@ -153,9 +179,11 @@ class NewGeographicalMarketControllerSpec extends UnitSpec with MockitoSugar wit
     }
   }
 
-  "Sending a valid 'No' form submit to the NewGeographicalMarketController when authenticated" should {
+  "Sending a valid 'No' form submit to the NewGeographicalMarketController when authenticated and enrolled" should {
     "redirect the ten year plan page" in {
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
+      when(NewGeographicalMarketControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       val formInput = "isNewGeographicalMarket" -> Constants.StandardRadioButtonNoValue
       submitWithSessionAndAuth(NewGeographicalMarketControllerTest.submit, formInput)(
         result => {
@@ -166,10 +194,12 @@ class NewGeographicalMarketControllerSpec extends UnitSpec with MockitoSugar wit
     }
   }
 
-  "Sending an invalid form submission with validation errors to the NewGeographicalMarketController with no backlink and when authenticated" should {
+  "Sending an invalid form submission with validation errors to the NewGeographicalMarketController with no backlink and when authenticated and enrolled" should {
     "redirect to WhatWillUseFor page" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkNewGeoMarket))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
+      when(NewGeographicalMarketControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       val formInput = "isNewGeographicalMarket" -> ""
       submitWithSessionAndAuth(NewGeographicalMarketControllerTest.submit, formInput)(
         result => {
@@ -180,10 +210,12 @@ class NewGeographicalMarketControllerSpec extends UnitSpec with MockitoSugar wit
     }
   }
 
-  "Sending an invalid form submission with validation errors to the NewGeographicalMarketController when authenticated" should {
+  "Sending an invalid form submission with validation errors to the NewGeographicalMarketController when authenticated and enrolled" should {
     "redirect to itself with errors" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkNewGeoMarket))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.WhatWillUseForController.show().toString())))
+      when(NewGeographicalMarketControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       val formInput = "isNewGeographicalMarket" -> ""
       submitWithSessionAndAuth(NewGeographicalMarketControllerTest.submit, formInput)(
         result => {
@@ -224,6 +256,19 @@ class NewGeographicalMarketControllerSpec extends UnitSpec with MockitoSugar wit
         result => {
           status(result) shouldBe SEE_OTHER
           redirectLocation(result) shouldBe Some(routes.TimeoutController.timeout().url)
+        }
+      )
+    }
+  }
+
+  "Sending a submission to the NewGeographicalMarketController when NOT enrolled" should {
+    "redirect to the Timeout page when session has timed out" in {
+      when(NewGeographicalMarketControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(None))
+      submitWithSessionAndAuth(NewGeographicalMarketControllerTest.submit)(
+        result => {
+          status(result) shouldBe SEE_OTHER
+          redirectLocation(result) shouldBe Some(FrontendAppConfig.subscriptionUrl)
         }
       )
     }

--- a/test/controllers/NewProductControllerSpec.scala
+++ b/test/controllers/NewProductControllerSpec.scala
@@ -48,6 +48,12 @@ class NewProductControllerSpec extends UnitSpec with MockitoSugar with BeforeAnd
     override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
+  private def mockEnrolledRequest = when(NewProductControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+
+  private def mockNotEnrolledRequest = when(NewProductControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(None))
+
   val modelYes = NewProductModel(Constants.StandardRadioButtonYesValue)
   val modelNo = NewProductModel(Constants.StandardRadioButtonNoValue)
   val emptyModel = NewProductModel("")
@@ -80,8 +86,7 @@ class NewProductControllerSpec extends UnitSpec with MockitoSugar with BeforeAnd
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[NewProductModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedNewProduct)))
-      when(NewProductControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(NewProductControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -91,8 +96,7 @@ class NewProductControllerSpec extends UnitSpec with MockitoSugar with BeforeAnd
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[NewProductModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(NewProductControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(NewProductControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -104,8 +108,7 @@ class NewProductControllerSpec extends UnitSpec with MockitoSugar with BeforeAnd
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[NewProductModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedNewProduct)))
-      when(NewProductControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       showWithSessionAndAuth(NewProductControllerTest.show)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -157,8 +160,7 @@ class NewProductControllerSpec extends UnitSpec with MockitoSugar with BeforeAnd
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesModel](Matchers.eq(KeystoreKeys.subsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(modelSubsidiariesYes)))
-      when(NewProductControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "isNewProduct" -> Constants.StandardRadioButtonYesValue
       submitWithSessionAndAuth(NewProductControllerTest.submit,formInput)(
         result => {
@@ -175,8 +177,7 @@ class NewProductControllerSpec extends UnitSpec with MockitoSugar with BeforeAnd
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesModel](Matchers.eq(KeystoreKeys.subsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(modelSubsidiariesNo)))
-      when(NewProductControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "isNewProduct" -> Constants.StandardRadioButtonYesValue
       submitWithSessionAndAuth(NewProductControllerTest.submit, formInput)(
         result => {
@@ -192,8 +193,7 @@ class NewProductControllerSpec extends UnitSpec with MockitoSugar with BeforeAnd
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesModel](Matchers.eq(KeystoreKeys.subsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(NewProductControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "isNewProduct" -> Constants.StandardRadioButtonYesValue
       submitWithSessionAndAuth(NewProductControllerTest.submit, formInput)(
         result => {
@@ -213,8 +213,7 @@ class NewProductControllerSpec extends UnitSpec with MockitoSugar with BeforeAnd
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesModel](Matchers.eq(KeystoreKeys.subsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(modelSubsidiariesYes)))
-      when(NewProductControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "isNewProduct" -> Constants.StandardRadioButtonNoValue
       submitWithSessionAndAuth(NewProductControllerTest.submit, formInput)(
         result => {
@@ -230,8 +229,7 @@ class NewProductControllerSpec extends UnitSpec with MockitoSugar with BeforeAnd
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesModel](Matchers.eq(KeystoreKeys.subsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(modelSubsidiariesNo)))
-      when(NewProductControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "isNewProduct" -> Constants.StandardRadioButtonNoValue
       submitWithSessionAndAuth(NewProductControllerTest.submit, formInput)(
         result => {
@@ -247,8 +245,7 @@ class NewProductControllerSpec extends UnitSpec with MockitoSugar with BeforeAnd
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesModel](Matchers.eq(KeystoreKeys.subsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(NewProductControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "isNewProduct" -> Constants.StandardRadioButtonNoValue
       submitWithSessionAndAuth(NewProductControllerTest.submit, formInput)(
         result => {
@@ -261,8 +258,7 @@ class NewProductControllerSpec extends UnitSpec with MockitoSugar with BeforeAnd
 
   "Sending an invalid form submission with validation errors to the NewProductController when authenticated and enrolled" should {
     "redirect to itself" in {
-      when(NewProductControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "isNewProduct" -> ""
       submitWithSessionAndAuth(NewProductControllerTest.submit, formInput)(
         result => {
@@ -310,8 +306,7 @@ class NewProductControllerSpec extends UnitSpec with MockitoSugar with BeforeAnd
 
   "Sending a submission to the NewProductController when NOT enrolled" should {
     "redirect to the Subscription Service" in {
-      when(NewProductControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       submitWithSessionAndAuth(NewProductControllerTest.submit)(
         result => {
           status(result) shouldBe SEE_OTHER

--- a/test/controllers/NewProductControllerSpec.scala
+++ b/test/controllers/NewProductControllerSpec.scala
@@ -18,10 +18,10 @@ package controllers
 
 import java.net.URLEncoder
 
-import auth.{MockAuthConnector, MockConfig}
+import auth.{Enrolment, Identifier, MockAuthConnector, MockConfig}
 import common.{Constants, KeystoreKeys}
 import config.{FrontendAppConfig, FrontendAuthConnector}
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.helpers.FakeRequestHelper
 import models._
 import org.mockito.Matchers
@@ -45,6 +45,7 @@ class NewProductControllerSpec extends UnitSpec with MockitoSugar with BeforeAnd
     override lazy val applicationConfig = FrontendAppConfig
     override lazy val authConnector = MockAuthConnector
     val keyStoreConnector: KeystoreConnector = mockKeyStoreConnector
+    override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
   val modelYes = NewProductModel(Constants.StandardRadioButtonYesValue)
@@ -74,22 +75,42 @@ class NewProductControllerSpec extends UnitSpec with MockitoSugar with BeforeAnd
     }
   }
 
-  "Sending a GET request to NewProductController when authenticated" should {
+  "Sending a GET request to NewProductController when authenticated and enrolled" should {
     "return a 200 when something is fetched from keystore" in {
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[NewProductModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedNewProduct)))
+      when(NewProductControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       showWithSessionAndAuth(NewProductControllerTest.show)(
         result => status(result) shouldBe OK
       )
     }
 
-    "provide an empty model and return a 200 when nothing is fetched using keystore when authenticated" in {
+    "provide an empty model and return a 200 when nothing is fetched using keystore when authenticated and enrolled" in {
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[NewProductModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
+      when(NewProductControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       showWithSessionAndAuth(NewProductControllerTest.show)(
         result => status(result) shouldBe OK
+      )
+    }
+  }
+
+  "Sending a GET request to NewProductController when authenticated and NOT enrolled" should {
+    "redirect to the Subscription Service" in {
+      when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
+      when(mockKeyStoreConnector.fetchAndGetFormData[NewProductModel](Matchers.any())(Matchers.any(), Matchers.any()))
+        .thenReturn(Future.successful(Option(keyStoreSavedNewProduct)))
+      when(NewProductControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(None))
+      showWithSessionAndAuth(NewProductControllerTest.show)(
+        result => {
+          status(result) shouldBe SEE_OTHER
+          redirectLocation(result) shouldBe Some(FrontendAppConfig.subscriptionUrl)
+        }
       )
     }
   }
@@ -131,11 +152,13 @@ class NewProductControllerSpec extends UnitSpec with MockitoSugar with BeforeAnd
     }
   }
 
-  "Sending a valid 'Yes' form submit to the NewProductController when authenticated" should {
+  "Sending a valid 'Yes' form submit to the NewProductController when authenticated and enrolled" should {
     "redirect to the subsidiaries spending investment page when the subsidiaries value is Yes" in {
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesModel](Matchers.eq(KeystoreKeys.subsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(modelSubsidiariesYes)))
+      when(NewProductControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       val formInput = "isNewProduct" -> Constants.StandardRadioButtonYesValue
       submitWithSessionAndAuth(NewProductControllerTest.submit,formInput)(
         result => {
@@ -147,11 +170,13 @@ class NewProductControllerSpec extends UnitSpec with MockitoSugar with BeforeAnd
   }
 
 
-  "Sending a valid 'Yes' form submit to the NewProductController when authenticated" should {
+  "Sending a valid 'Yes' form submit to the NewProductController when authenticated and enrolled" should {
     "redirect to how use investment (how grow) page when the subsidiaries value is No" in {
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesModel](Matchers.eq(KeystoreKeys.subsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(modelSubsidiariesNo)))
+      when(NewProductControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       val formInput = "isNewProduct" -> Constants.StandardRadioButtonYesValue
       submitWithSessionAndAuth(NewProductControllerTest.submit, formInput)(
         result => {
@@ -162,11 +187,13 @@ class NewProductControllerSpec extends UnitSpec with MockitoSugar with BeforeAnd
     }
   }
 
-  "Sending a valid 'Yes' form submit to the NewProductController when authenticated" should {
+  "Sending a valid 'Yes' form submit to the NewProductController when authenticated and enrolled" should {
     "redirect to the subsidiaries page when the subsidiaries value is not present" in {
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesModel](Matchers.eq(KeystoreKeys.subsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
+      when(NewProductControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       val formInput = "isNewProduct" -> Constants.StandardRadioButtonYesValue
       submitWithSessionAndAuth(NewProductControllerTest.submit, formInput)(
         result => {
@@ -181,11 +208,13 @@ class NewProductControllerSpec extends UnitSpec with MockitoSugar with BeforeAnd
   // the No sections below will be much simplified later as they will just go to the required error page
   // (or in page javascript to make it red in which case not part of navigation at all and no controller test required)
   // The subsidiaries logic test is not required in the 3 tests below can be replaced by a single test  top the error page
-  "Sending a valid 'No' form submit to the NewProductController when authenticated" should {
+  "Sending a valid 'No' form submit to the NewProductController when authenticated and enrolled" should {
     "redirect to the subsidiaries page when the subsidiaries value is Yes" in {
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesModel](Matchers.eq(KeystoreKeys.subsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(modelSubsidiariesYes)))
+      when(NewProductControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       val formInput = "isNewProduct" -> Constants.StandardRadioButtonNoValue
       submitWithSessionAndAuth(NewProductControllerTest.submit, formInput)(
         result => {
@@ -196,11 +225,13 @@ class NewProductControllerSpec extends UnitSpec with MockitoSugar with BeforeAnd
     }
   }
 
-  "Sending a valid 'No' form submit to the NewProductController when authenticated" should {
+  "Sending a valid 'No' form submit to the NewProductController when authenticated and enrolled" should {
     "redirect to the subsidiaries page when the subsidiaries value is No" in {
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesModel](Matchers.eq(KeystoreKeys.subsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(modelSubsidiariesNo)))
+      when(NewProductControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       val formInput = "isNewProduct" -> Constants.StandardRadioButtonNoValue
       submitWithSessionAndAuth(NewProductControllerTest.submit, formInput)(
         result => {
@@ -211,11 +242,13 @@ class NewProductControllerSpec extends UnitSpec with MockitoSugar with BeforeAnd
     }
   }
 
-  "Sending a valid 'No' form submit to the NewProductController when authenticated" should {
+  "Sending a valid 'No' form submit to the NewProductController when authenticated and enrolled" should {
     "redirect to the subsidiaries page when the subsidiaries value is not present" in {
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesModel](Matchers.eq(KeystoreKeys.subsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
+      when(NewProductControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       val formInput = "isNewProduct" -> Constants.StandardRadioButtonNoValue
       submitWithSessionAndAuth(NewProductControllerTest.submit, formInput)(
         result => {
@@ -226,8 +259,10 @@ class NewProductControllerSpec extends UnitSpec with MockitoSugar with BeforeAnd
     }
   }
 
-  "Sending an invalid form submission with validation errors to the NewProductController when authenticated" should {
+  "Sending an invalid form submission with validation errors to the NewProductController when authenticated and enrolled" should {
     "redirect to itself" in {
+      when(NewProductControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       val formInput = "isNewProduct" -> ""
       submitWithSessionAndAuth(NewProductControllerTest.submit, formInput)(
         result => {
@@ -268,6 +303,19 @@ class NewProductControllerSpec extends UnitSpec with MockitoSugar with BeforeAnd
         result => {
           status(result) shouldBe SEE_OTHER
           redirectLocation(result) shouldBe Some(routes.TimeoutController.timeout().url)
+        }
+      )
+    }
+  }
+
+  "Sending a submission to the NewProductController when NOT enrolled" should {
+    "redirect to the Subscription Service" in {
+      when(NewProductControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(None))
+      submitWithSessionAndAuth(NewProductControllerTest.submit)(
+        result => {
+          status(result) shouldBe SEE_OTHER
+          redirectLocation(result) shouldBe Some(FrontendAppConfig.subscriptionUrl)
         }
       )
     }

--- a/test/controllers/OperatingCostsControllerSpec.scala
+++ b/test/controllers/OperatingCostsControllerSpec.scala
@@ -50,6 +50,12 @@ class OperatingCostsControllerSpec extends UnitSpec with MockitoSugar with Befor
     override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
+  private def mockEnrolledRequest = when(OperatingCostsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+
+  private def mockNotEnrolledRequest = when(OperatingCostsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(None))
+
   val operatingCostsAsJson =
     """{"operatingCosts1stYear" : 750000, "operatingCosts2ndYear" : 800000, "operatingCosts3rdYear" : 934000,
       | "rAndDCosts1stYear" : 231000, "rAndDCosts2ndYear" : 340000, "rAndDCosts3rdYear" : 344000}""".stripMargin
@@ -95,8 +101,7 @@ class OperatingCostsControllerSpec extends UnitSpec with MockitoSugar with Befor
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[OperatingCostsModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSaved10PercBoundaryOC)))
-      when(OperatingCostsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(OperatingCostsControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -106,8 +111,7 @@ class OperatingCostsControllerSpec extends UnitSpec with MockitoSugar with Befor
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[OperatingCostsModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(OperatingCostsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(OperatingCostsControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -119,8 +123,7 @@ class OperatingCostsControllerSpec extends UnitSpec with MockitoSugar with Befor
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[OperatingCostsModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSaved10PercBoundaryOC)))
-      when(OperatingCostsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       showWithSessionAndAuth(OperatingCostsControllerTest.show)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -174,8 +177,7 @@ class OperatingCostsControllerSpec extends UnitSpec with MockitoSugar with Befor
       when(mockKeyStoreConnector.saveFormData(Matchers.eq(KeystoreKeys.operatingCosts), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[KiProcessingModel](Matchers.eq(KeystoreKeys.kiProcessingModel))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(trueKIModel)))
-      when(OperatingCostsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = Seq(
         "operatingCosts1stYear" -> "1000",
         "operatingCosts2ndYear" -> "1000",
@@ -201,8 +203,7 @@ class OperatingCostsControllerSpec extends UnitSpec with MockitoSugar with Befor
       when(mockKeyStoreConnector.saveFormData(Matchers.eq(KeystoreKeys.operatingCosts), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[KiProcessingModel](Matchers.eq(KeystoreKeys.kiProcessingModel))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(trueKIModel)))
-      when(OperatingCostsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = Seq(
         "operatingCosts1stYear" -> "1000",
         "operatingCosts2ndYear" -> "1000",
@@ -227,8 +228,7 @@ class OperatingCostsControllerSpec extends UnitSpec with MockitoSugar with Befor
       when(mockKeyStoreConnector.saveFormData(Matchers.eq(KeystoreKeys.operatingCosts), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[KiProcessingModel](Matchers.eq(KeystoreKeys.kiProcessingModel))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(trueKIModel)))
-      when(OperatingCostsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
 
       val formInput = Seq(
         "operatingCosts1stYear" -> "0",
@@ -254,8 +254,7 @@ class OperatingCostsControllerSpec extends UnitSpec with MockitoSugar with Befor
       when(mockKeyStoreConnector.saveFormData(Matchers.eq(KeystoreKeys.operatingCosts), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[KiProcessingModel](Matchers.eq(KeystoreKeys.kiProcessingModel))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(emptyKIModel)))
-      when(OperatingCostsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = Seq(
         "operatingCosts1stYear" -> "100",
         "operatingCosts2ndYear" -> "100",
@@ -281,8 +280,7 @@ class OperatingCostsControllerSpec extends UnitSpec with MockitoSugar with Befor
       when(mockKeyStoreConnector.saveFormData(Matchers.eq(KeystoreKeys.operatingCosts), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[KiProcessingModel](Matchers.eq(KeystoreKeys.kiProcessingModel))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(OperatingCostsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = Seq(
         "operatingCosts1stYear" -> "100",
         "operatingCosts2ndYear" -> "100",
@@ -308,8 +306,7 @@ class OperatingCostsControllerSpec extends UnitSpec with MockitoSugar with Befor
       when(mockKeyStoreConnector.saveFormData(Matchers.eq(KeystoreKeys.operatingCosts), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[KiProcessingModel](Matchers.eq(KeystoreKeys.kiProcessingModel))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(missingKIModel)))
-      when(OperatingCostsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = Seq(
         "operatingCosts1stYear" -> "100",
         "operatingCosts2ndYear" -> "100",
@@ -335,8 +332,7 @@ class OperatingCostsControllerSpec extends UnitSpec with MockitoSugar with Befor
       when(mockKeyStoreConnector.saveFormData(Matchers.eq(KeystoreKeys.operatingCosts), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[KiProcessingModel](Matchers.eq(KeystoreKeys.kiProcessingModel))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(falseKIModel)))
-      when(OperatingCostsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = Seq(
         "operatingCosts1stYear" -> "100",
         "operatingCosts2ndYear" -> "100",
@@ -360,8 +356,7 @@ class OperatingCostsControllerSpec extends UnitSpec with MockitoSugar with Befor
 
       when(mockKeyStoreConnector.fetchAndGetFormData[OperatingCostsModel](Matchers.eq(KeystoreKeys.operatingCosts))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSaved10PercBoundaryOC)))
-      when(OperatingCostsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = Seq(
         "operatingCosts1stYear" -> " ",
         "operatingCosts2ndYear" -> " ",
@@ -383,8 +378,7 @@ class OperatingCostsControllerSpec extends UnitSpec with MockitoSugar with Befor
 
   "Sending an invalid form with missing data submission with validation errors to the OperatingCostsController when authenticated and enrolled" should {
     "return a bad request" in {
-      when(OperatingCostsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = Seq(
         "operatingCosts1stYear" -> "230000",
         "operatingCosts2ndYear" -> "189250",
@@ -404,8 +398,7 @@ class OperatingCostsControllerSpec extends UnitSpec with MockitoSugar with Befor
 
   "Sending an invalid form with invalid data submission with validation errors to the OperatingCostsController when authenticated and enrolled" should {
     "return a bad request" in {
-      when(OperatingCostsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = Seq(
         "operatingCosts1stYear" -> "230000",
         "operatingCosts2ndYear" -> "189250",
@@ -461,8 +454,7 @@ class OperatingCostsControllerSpec extends UnitSpec with MockitoSugar with Befor
 
   "Sending a submission to the ContactDetailsController when NOT enrolled" should {
     "redirect to the Subscription Service" in {
-      when(OperatingCostsControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       submitWithSessionAndAuth(OperatingCostsControllerTest.submit)(
         result => {
           status(result) shouldBe SEE_OTHER

--- a/test/controllers/PercentageStaffWithMastersControllerSpec.scala
+++ b/test/controllers/PercentageStaffWithMastersControllerSpec.scala
@@ -50,6 +50,12 @@ class PercentageStaffWithMastersControllerSpec extends UnitSpec with MockitoSuga
     override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
+  private def mockEnrolledRequest = when(PercentageStaffWithMastersControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+
+  private def mockNotEnrolledRequest = when(PercentageStaffWithMastersControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(None))
+
   val modelYes = PercentageStaffWithMastersModel(Constants.StandardRadioButtonYesValue)
   val modelNo = PercentageStaffWithMastersModel(Constants.StandardRadioButtonNoValue)
   val emptyModel = PercentageStaffWithMastersModel("")
@@ -84,8 +90,7 @@ class PercentageStaffWithMastersControllerSpec extends UnitSpec with MockitoSuga
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[PercentageStaffWithMastersModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedPercentageStaffWithMasters)))
-      when(PercentageStaffWithMastersControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(PercentageStaffWithMastersControllerTest.show())(
         result => status(result) shouldBe OK
       )
@@ -97,8 +102,7 @@ class PercentageStaffWithMastersControllerSpec extends UnitSpec with MockitoSuga
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[PercentageStaffWithMastersModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(PercentageStaffWithMastersControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(PercentageStaffWithMastersControllerTest.show())(
         result => status(result) shouldBe OK
       )
@@ -112,8 +116,7 @@ class PercentageStaffWithMastersControllerSpec extends UnitSpec with MockitoSuga
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[PercentageStaffWithMastersModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedPercentageStaffWithMasters)))
-      when(PercentageStaffWithMastersControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       showWithSessionAndAuth(PercentageStaffWithMastersControllerTest.show())(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -167,8 +170,7 @@ class PercentageStaffWithMastersControllerSpec extends UnitSpec with MockitoSuga
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[KiProcessingModel](Matchers.eq(KeystoreKeys.kiProcessingModel))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(trueKIModel)))
-      when(PercentageStaffWithMastersControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "staffWithMasters" -> Constants.StandardRadioButtonYesValue
       submitWithSessionAndAuth(PercentageStaffWithMastersControllerTest.submit,formInput)(
         result => {
@@ -186,8 +188,7 @@ class PercentageStaffWithMastersControllerSpec extends UnitSpec with MockitoSuga
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[KiProcessingModel](Matchers.eq(KeystoreKeys.kiProcessingModel))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(isKiKIModel)))
-      when(PercentageStaffWithMastersControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "staffWithMasters" -> Constants.StandardRadioButtonYesValue
       submitWithSessionAndAuth(PercentageStaffWithMastersControllerTest.submit,formInput)(
         result => {
@@ -205,8 +206,7 @@ class PercentageStaffWithMastersControllerSpec extends UnitSpec with MockitoSuga
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[KiProcessingModel](Matchers.eq(KeystoreKeys.kiProcessingModel))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(PercentageStaffWithMastersControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "staffWithMasters" -> Constants.StandardRadioButtonYesValue
       submitWithSessionAndAuth(PercentageStaffWithMastersControllerTest.submit,formInput)(
         result => {
@@ -224,8 +224,7 @@ class PercentageStaffWithMastersControllerSpec extends UnitSpec with MockitoSuga
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[KiProcessingModel](Matchers.eq(KeystoreKeys.kiProcessingModel))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(missingDataKIModel)))
-      when(PercentageStaffWithMastersControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "staffWithMasters" -> Constants.StandardRadioButtonYesValue
       submitWithSessionAndAuth(PercentageStaffWithMastersControllerTest.submit,formInput)(
         result => {
@@ -243,8 +242,7 @@ class PercentageStaffWithMastersControllerSpec extends UnitSpec with MockitoSuga
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[KiProcessingModel](Matchers.eq(KeystoreKeys.kiProcessingModel))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(trueKIModel)))
-      when(PercentageStaffWithMastersControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "staffWithMasters" -> Constants.StandardRadioButtonNoValue
       submitWithSessionAndAuth(PercentageStaffWithMastersControllerTest.submit,formInput)(
         result => {
@@ -257,8 +255,7 @@ class PercentageStaffWithMastersControllerSpec extends UnitSpec with MockitoSuga
   
   "Sending an invalid form submission with validation errors to the PercentageStaffWithMastersController when Authenticated and enrolled" should {
     "redirect to itself" in {
-      when(PercentageStaffWithMastersControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "staffWithMasters" -> ""
       submitWithSessionAndAuth(PercentageStaffWithMastersControllerTest.submit,formInput)(
         result => {
@@ -306,8 +303,7 @@ class PercentageStaffWithMastersControllerSpec extends UnitSpec with MockitoSuga
 
   "Sending a submission to the ContactDetailsController when NOT enrolled" should {
     "redirect to the Subscription Service" in {
-      when(PercentageStaffWithMastersControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       submitWithSessionAndAuth(PercentageStaffWithMastersControllerTest.submit)(
         result => {
           status(result) shouldBe SEE_OTHER

--- a/test/controllers/PreviousBeforeDOFCSControllerSpec.scala
+++ b/test/controllers/PreviousBeforeDOFCSControllerSpec.scala
@@ -48,6 +48,12 @@ class PreviousBeforeDOFCSControllerSpec extends UnitSpec with MockitoSugar with 
     override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
+  private def mockEnrolledRequest = when(PreviousBeforeDOFCSControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+
+  private def mockNotEnrolledRequest = when(PreviousBeforeDOFCSControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(None))
+
   val modelYes = PreviousBeforeDOFCSModel(Constants.StandardRadioButtonYesValue)
   val modelNo = PreviousBeforeDOFCSModel(Constants.StandardRadioButtonNoValue)
   val emptyModel = PreviousBeforeDOFCSModel("")
@@ -76,8 +82,7 @@ class PreviousBeforeDOFCSControllerSpec extends UnitSpec with MockitoSugar with 
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[PreviousBeforeDOFCSModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedPreviousBeforeDOFCS)))
-      when(PreviousBeforeDOFCSControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(PreviousBeforeDOFCSControllerTest.show())(
         result => status(result) shouldBe OK
       )
@@ -87,8 +92,7 @@ class PreviousBeforeDOFCSControllerSpec extends UnitSpec with MockitoSugar with 
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[PreviousBeforeDOFCSModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(PreviousBeforeDOFCSControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(PreviousBeforeDOFCSControllerTest.show())(
         result => status(result) shouldBe OK
       )
@@ -100,8 +104,7 @@ class PreviousBeforeDOFCSControllerSpec extends UnitSpec with MockitoSugar with 
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[PreviousBeforeDOFCSModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedPreviousBeforeDOFCS)))
-      when(PreviousBeforeDOFCSControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       showWithSessionAndAuth(PreviousBeforeDOFCSControllerTest.show())(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -113,8 +116,7 @@ class PreviousBeforeDOFCSControllerSpec extends UnitSpec with MockitoSugar with 
 
   "Sending an Unauthenticated formInput with a session to PreviousBeforeDOFCSController when Authenticated and enrolled" should {
     "return a 302 and redirect to GG login" in {
-      when(PreviousBeforeDOFCSControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionWithoutAuth(PreviousBeforeDOFCSControllerTest.show())(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -128,8 +130,7 @@ class PreviousBeforeDOFCSControllerSpec extends UnitSpec with MockitoSugar with 
 
   "Sending a formInput with no session to PreviousBeforeDOFCSController when Authenticated and enrolled" should {
     "return a 302 and redirect to GG login" in {
-      when(PreviousBeforeDOFCSControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithoutSession(PreviousBeforeDOFCSControllerTest.show())(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -143,8 +144,7 @@ class PreviousBeforeDOFCSControllerSpec extends UnitSpec with MockitoSugar with 
 
   "Sending a timed-out formInput to PreviousBeforeDOFCSController when Authenticated and enrolled" should {
     "return a 302 and redirect to the timeout page" in {
-      when(PreviousBeforeDOFCSControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithTimeout(PreviousBeforeDOFCSControllerTest.show())(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -156,8 +156,7 @@ class PreviousBeforeDOFCSControllerSpec extends UnitSpec with MockitoSugar with 
 
   "Sending a valid 'No' form submit to the PreviousBeforeDOFCSController when Authenticated and enrolled" should {
     "redirect to new geographical market" in {
-      when(PreviousBeforeDOFCSControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "previousBeforeDOFCS" -> Constants.StandardRadioButtonNoValue
       submitWithSessionAndAuth(PreviousBeforeDOFCSControllerTest.submit, formInput)(
         result => {
@@ -173,8 +172,7 @@ class PreviousBeforeDOFCSControllerSpec extends UnitSpec with MockitoSugar with 
      when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesModel](Matchers.eq(KeystoreKeys.subsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesNo)))
-      when(PreviousBeforeDOFCSControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "previousBeforeDOFCS" -> Constants.StandardRadioButtonYesValue
       submitWithSessionAndAuth(PreviousBeforeDOFCSControllerTest.submit, formInput)(
         result => {
@@ -190,8 +188,7 @@ class PreviousBeforeDOFCSControllerSpec extends UnitSpec with MockitoSugar with 
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesModel](Matchers.eq(KeystoreKeys.subsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesYes)))
-      when(PreviousBeforeDOFCSControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "previousBeforeDOFCS" -> Constants.StandardRadioButtonYesValue
       submitWithSessionAndAuth(PreviousBeforeDOFCSControllerTest.submit, formInput)(
         result => {
@@ -207,8 +204,7 @@ class PreviousBeforeDOFCSControllerSpec extends UnitSpec with MockitoSugar with 
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesModel](Matchers.eq(KeystoreKeys.subsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesYes)))
-      when(PreviousBeforeDOFCSControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "previousBeforeDOFCS" -> Constants.StandardRadioButtonNoValue
       submitWithSessionAndAuth(PreviousBeforeDOFCSControllerTest.submit, formInput)(
         result => {
@@ -224,8 +220,7 @@ class PreviousBeforeDOFCSControllerSpec extends UnitSpec with MockitoSugar with 
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesModel](Matchers.eq(KeystoreKeys.subsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesNo)))
-      when(PreviousBeforeDOFCSControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "previousBeforeDOFCS" -> Constants.StandardRadioButtonNoValue
       submitWithSessionAndAuth(PreviousBeforeDOFCSControllerTest.submit, formInput)(
         result => {
@@ -241,8 +236,7 @@ class PreviousBeforeDOFCSControllerSpec extends UnitSpec with MockitoSugar with 
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesModel](Matchers.eq(KeystoreKeys.subsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(PreviousBeforeDOFCSControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "previousBeforeDOFCS" -> Constants.StandardRadioButtonYesValue
       submitWithSessionAndAuth(PreviousBeforeDOFCSControllerTest.submit, formInput)(
         result => {
@@ -256,8 +250,7 @@ class PreviousBeforeDOFCSControllerSpec extends UnitSpec with MockitoSugar with 
 
   "Sending an invalid form submission with validation errors to the PreviousBeforeDOFCSController when Authenticated and enrolled" should {
     "redirect to itself" in {
-      when(PreviousBeforeDOFCSControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "previousBeforeDOFCS" -> ""
       submitWithSessionAndAuth(PreviousBeforeDOFCSControllerTest.submit, formInput)(
         result => {
@@ -306,8 +299,7 @@ class PreviousBeforeDOFCSControllerSpec extends UnitSpec with MockitoSugar with 
 
   "Sending a submission to the PreviousBeforeDOFCSController when NOT enrolled" should {
     "redirect to the Subscription Service" in {
-      when(PreviousBeforeDOFCSControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       submitWithSessionAndAuth(PreviousBeforeDOFCSControllerTest.submit)(
         result => {
           status(result) shouldBe SEE_OTHER

--- a/test/controllers/PreviousSchemeControllerSpec.scala
+++ b/test/controllers/PreviousSchemeControllerSpec.scala
@@ -49,6 +49,12 @@ class PreviousSchemeControllerSpec extends UnitSpec with MockitoSugar with Befor
     override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
+  private def mockEnrolledRequest = when(PreviousSchemeControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+
+  private def mockNotEnrolledRequest = when(PreviousSchemeControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(None))
+
   val model = PreviousSchemeModel(
     Constants.PageInvestmentSchemeEisValue, 2356, None, None, Some(4), Some(12), Some(2009), Some(1))
   val model2 = PreviousSchemeModel(
@@ -90,8 +96,7 @@ class PreviousSchemeControllerSpec extends UnitSpec with MockitoSugar with Befor
       when(mockKeyStoreConnector.fetchAndGetFormData[String]
         (Matchers.eq(KeystoreKeys.backLinkPreviousScheme))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.ReviewPreviousSchemesController.show().toString())))
-      when(PreviousSchemeControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(PreviousSchemeControllerTest.show(None))(
         result => status(result) shouldBe OK
       )
@@ -104,8 +109,7 @@ class PreviousSchemeControllerSpec extends UnitSpec with MockitoSugar with Befor
       when(mockKeyStoreConnector.fetchAndGetFormData[String]
         (Matchers.eq(KeystoreKeys.backLinkPreviousScheme))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.ReviewPreviousSchemesController.show().toString())))
-      when(PreviousSchemeControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(PreviousSchemeControllerTest.show(Some(1)))(
         result => status(result) shouldBe OK
       )
@@ -120,8 +124,7 @@ class PreviousSchemeControllerSpec extends UnitSpec with MockitoSugar with Befor
       when(mockKeyStoreConnector.fetchAndGetFormData[String]
         (Matchers.eq(KeystoreKeys.backLinkPreviousScheme))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.ReviewPreviousSchemesController.show().toString())))
-      when(PreviousSchemeControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       showWithSessionAndAuth(PreviousSchemeControllerTest.show(None))(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -244,8 +247,7 @@ class PreviousSchemeControllerSpec extends UnitSpec with MockitoSugar with Befor
       when(mockKeyStoreConnector.fetchAndGetFormData[String]
         (Matchers.eq(KeystoreKeys.backLinkPreviousScheme))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.ReviewPreviousSchemesController.show().toString())))
-      when(PreviousSchemeControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = Seq(
         "schemeTypeDesc" -> Constants.PageInvestmentSchemeAnotherValue,
         "investmentAmount" -> "12345",
@@ -275,8 +277,7 @@ class PreviousSchemeControllerSpec extends UnitSpec with MockitoSugar with Befor
       when(mockKeyStoreConnector.fetchAndGetFormData[String]
         (Matchers.eq(KeystoreKeys.backLinkPreviousScheme))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.ReviewPreviousSchemesController.show().toString())))
-      when(PreviousSchemeControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = Seq(
         "schemeTypeDesc" -> Constants.PageInvestmentSchemeSeisValue,
         "investmentAmount" -> "666",
@@ -307,8 +308,7 @@ class PreviousSchemeControllerSpec extends UnitSpec with MockitoSugar with Befor
       when(mockKeyStoreConnector.fetchAndGetFormData[String]
         (Matchers.eq(KeystoreKeys.backLinkPreviousScheme))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.ReviewPreviousSchemesController.show().toString())))
-      when(PreviousSchemeControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = Seq(
         "schemeTypeDesc" -> Constants.PageInvestmentSchemeAnotherValue,
         "investmentAmount" -> "",
@@ -337,8 +337,7 @@ class PreviousSchemeControllerSpec extends UnitSpec with MockitoSugar with Befor
       when(mockKeyStoreConnector.fetchAndGetFormData[String]
         (Matchers.eq(KeystoreKeys.backLinkPreviousScheme))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.ReviewPreviousSchemesController.show().toString())))
-      when(PreviousSchemeControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = Seq(
         "schemeTypeDesc" -> Constants.PageInvestmentSchemeVctValue,
         "investmentAmount" -> "",
@@ -396,8 +395,7 @@ class PreviousSchemeControllerSpec extends UnitSpec with MockitoSugar with Befor
 
   "Sending a submission to the NewGeographicalMarketController when NOT enrolled" should {
     "redirect to the Subscription Service" in {
-      when(PreviousSchemeControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       submitWithSessionAndAuth(PreviousSchemeControllerTest.submit)(
         result => {
           status(result) shouldBe SEE_OTHER

--- a/test/controllers/ProposedInvestmentControllerSpec.scala
+++ b/test/controllers/ProposedInvestmentControllerSpec.scala
@@ -51,6 +51,12 @@ class ProposedInvestmentControllerSpec extends UnitSpec with MockitoSugar with B
     override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
+  private def mockEnrolledRequest = when(ProposedInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+
+  private def mockNotEnrolledRequest = when(ProposedInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(None))
+
   val model1 = PreviousSchemeModel(
     Constants.PageInvestmentSchemeEisValue, 2356, None, None, Some(4), Some(12), Some(2009), Some(1))
   val model2 = PreviousSchemeModel(
@@ -118,8 +124,7 @@ class ProposedInvestmentControllerSpec extends UnitSpec with MockitoSugar with B
       when(mockKeyStoreConnector.fetchAndGetFormData[String]
         (Matchers.eq(KeystoreKeys.backLinkProposedInvestment))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.ReviewPreviousSchemesController.show().toString())))
-      when(ProposedInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(ProposedInvestmentControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -134,8 +139,7 @@ class ProposedInvestmentControllerSpec extends UnitSpec with MockitoSugar with B
       when(mockKeyStoreConnector.fetchAndGetFormData[String]
         (Matchers.eq(KeystoreKeys.backLinkProposedInvestment))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.ReviewPreviousSchemesController.show().toString())))
-      when(ProposedInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(ProposedInvestmentControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -153,8 +157,7 @@ class ProposedInvestmentControllerSpec extends UnitSpec with MockitoSugar with B
       when(mockKeyStoreConnector.fetchAndGetFormData[String]
         (Matchers.eq(KeystoreKeys.backLinkProposedInvestment))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.ReviewPreviousSchemesController.show().toString())))
-      when(ProposedInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       showWithSessionAndAuth(ProposedInvestmentControllerTest.show)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -169,8 +172,7 @@ class ProposedInvestmentControllerSpec extends UnitSpec with MockitoSugar with B
       when(mockKeyStoreConnector.fetchAndGetFormData[String]
         (Matchers.eq(KeystoreKeys.backLinkProposedInvestment))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(ProposedInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(ProposedInvestmentControllerTest.show)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -182,8 +184,7 @@ class ProposedInvestmentControllerSpec extends UnitSpec with MockitoSugar with B
 
   "Sending an Unauthenticated request with a session to ProposedInvestmentController when authenticated and enrolled" should {
     "return a 302 and redirect to GG login" in {
-      when(ProposedInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionWithoutAuth(ProposedInvestmentControllerTest.show())(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -232,8 +233,7 @@ class ProposedInvestmentControllerSpec extends UnitSpec with MockitoSugar with B
         .thenReturn(Future.successful(Option(trueKIModel)))
       when(mockKeyStoreConnector.fetchAndGetFormData[Vector[PreviousSchemeModel]](Matchers.eq(KeystoreKeys.previousSchemes))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(previousSchemeTrueKIVectorList)))
-      when(ProposedInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "investmentAmount" -> "1234567"
       submitWithSessionAndAuth(ProposedInvestmentControllerTest.submit, formInput)(
         result => {
@@ -258,8 +258,7 @@ class ProposedInvestmentControllerSpec extends UnitSpec with MockitoSugar with B
         .thenReturn(Future.successful(Option(trueKIModel)))
       when(mockKeyStoreConnector.fetchAndGetFormData[Vector[PreviousSchemeModel]](Matchers.eq(KeystoreKeys.previousSchemes))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(previousSchemeTrueKIVectorList)))
-      when(ProposedInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "investmentAmount" -> "1234567"
       submitWithSessionAndAuth(ProposedInvestmentControllerTest.submit, formInput)(
         result => {
@@ -283,8 +282,7 @@ class ProposedInvestmentControllerSpec extends UnitSpec with MockitoSugar with B
         .thenReturn(Future.successful(Option(trueKIModel)))
       when(mockKeyStoreConnector.fetchAndGetFormData[Vector[PreviousSchemeModel]](Matchers.eq(KeystoreKeys.previousSchemes))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(previousSchemeOverTrueKIVectorList)))
-      when(ProposedInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "investmentAmount" -> "1234567"
       submitWithSessionAndAuth(ProposedInvestmentControllerTest.submit, formInput)(
         result => {
@@ -308,8 +306,7 @@ class ProposedInvestmentControllerSpec extends UnitSpec with MockitoSugar with B
         .thenReturn(Future.successful(Option(falseKIModel)))
       when(mockKeyStoreConnector.fetchAndGetFormData[Vector[PreviousSchemeModel]](Matchers.eq(KeystoreKeys.previousSchemes))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(previousSchemeFalseKIVectorList)))
-      when(ProposedInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "investmentAmount" -> "1234567"
       submitWithSessionAndAuth(ProposedInvestmentControllerTest.submit, formInput)(
         result => {
@@ -333,8 +330,7 @@ class ProposedInvestmentControllerSpec extends UnitSpec with MockitoSugar with B
         .thenReturn(Future.successful(Option(falseKIModel)))
       when(mockKeyStoreConnector.fetchAndGetFormData[Vector[PreviousSchemeModel]](Matchers.eq(KeystoreKeys.previousSchemes))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(previousSchemeOverFalseKIVectorList)))
-      when(ProposedInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "investmentAmount" -> "1234567"
       submitWithSessionAndAuth(ProposedInvestmentControllerTest.submit, formInput)(
         result => {
@@ -358,8 +354,7 @@ class ProposedInvestmentControllerSpec extends UnitSpec with MockitoSugar with B
         .thenReturn(Future.successful(Option(trueKIModel)))
       when(mockKeyStoreConnector.fetchAndGetFormData[Vector[PreviousSchemeModel]](Matchers.eq(KeystoreKeys.previousSchemes))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(previousSchemeUnderTotalAmount)))
-      when(ProposedInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "investmentAmount" -> "5000000"
       submitWithSessionAndAuth(ProposedInvestmentControllerTest.submit, formInput)(
         result => {
@@ -383,8 +378,7 @@ class ProposedInvestmentControllerSpec extends UnitSpec with MockitoSugar with B
         .thenReturn(Future.successful(None))
       when(mockKeyStoreConnector.fetchAndGetFormData[Vector[PreviousSchemeModel]](Matchers.eq(KeystoreKeys.previousSchemes))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(ProposedInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "investmentAmount" -> "1234567"
       submitWithSessionAndAuth(ProposedInvestmentControllerTest.submit, formInput)(
         result => {
@@ -400,8 +394,7 @@ class ProposedInvestmentControllerSpec extends UnitSpec with MockitoSugar with B
       when(mockKeyStoreConnector.fetchAndGetFormData[String]
         (Matchers.eq(KeystoreKeys.backLinkProposedInvestment))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.ReviewPreviousSchemesController.show().toString())))
-      when(ProposedInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "investmentAmount" -> "fff"
       submitWithSessionAndAuth(ProposedInvestmentControllerTest.submit, formInput)(
         result => {
@@ -416,8 +409,7 @@ class ProposedInvestmentControllerSpec extends UnitSpec with MockitoSugar with B
       when(mockKeyStoreConnector.fetchAndGetFormData[String]
         (Matchers.eq(KeystoreKeys.backLinkProposedInvestment))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.ReviewPreviousSchemesController.show().toString())))
-      when(ProposedInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "investmentAmount" -> "0"
       submitWithSessionAndAuth(ProposedInvestmentControllerTest.submit, formInput)(
         result => {
@@ -432,8 +424,7 @@ class ProposedInvestmentControllerSpec extends UnitSpec with MockitoSugar with B
       when(mockKeyStoreConnector.fetchAndGetFormData[String]
         (Matchers.eq(KeystoreKeys.backLinkProposedInvestment))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.ReviewPreviousSchemesController.show().toString())))
-      when(ProposedInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "investmentAmount" -> "5000001"
       submitWithSessionAndAuth(ProposedInvestmentControllerTest.submit, formInput)(
         result => {
@@ -481,8 +472,7 @@ class ProposedInvestmentControllerSpec extends UnitSpec with MockitoSugar with B
 
   "Sending a submission to the NewGeographicalMarketController when NOT enrolled" should {
     "redirect to the Subscription Servicec" in {
-      when(ProposedInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       submitWithSessionAndAuth(ProposedInvestmentControllerTest.submit)(
         result => {
           status(result) shouldBe SEE_OTHER

--- a/test/controllers/QualifyingForSchemeControllerSpec.scala
+++ b/test/controllers/QualifyingForSchemeControllerSpec.scala
@@ -40,6 +40,12 @@ class QualifyingForSchemeControllerSpec extends UnitSpec with MockitoSugar with 
     override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
+  private def mockEnrolledRequest = when(QualifyingForSchemeControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+
+  private def mockNotEnrolledRequest = when(QualifyingForSchemeControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(None))
+
   implicit val hc = HeaderCarrier()
 
   "QualifyingForSchemeController" should {
@@ -50,8 +56,7 @@ class QualifyingForSchemeControllerSpec extends UnitSpec with MockitoSugar with 
 
   "Sending a GET request to QualifyingForSchemeController when authenticated and enrolled" should {
     "return a 200 OK" in {
-      when(QualifyingForSchemeControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(QualifyingForSchemeControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -60,8 +65,7 @@ class QualifyingForSchemeControllerSpec extends UnitSpec with MockitoSugar with 
 
   "Sending an Unauthenticated request with a session to NewGeographicalMarketController when authenticated and enrolled" should {
     "return a 302 and redirect to GG login" in {
-      when(QualifyingForSchemeControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionWithoutAuth(QualifyingForSchemeControllerTest.show())(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -75,8 +79,7 @@ class QualifyingForSchemeControllerSpec extends UnitSpec with MockitoSugar with 
 
   "Sending an Unauthenticated request with a session to NewGeographicalMarketController when authenticated and NOT enrolled" should {
     "redirect to the Subscription Service" in {
-      when(QualifyingForSchemeControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       submitWithSessionAndAuth(QualifyingForSchemeControllerTest.show())(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -88,8 +91,7 @@ class QualifyingForSchemeControllerSpec extends UnitSpec with MockitoSugar with 
 
   "Sending a request with no session to NewGeographicalMarketController" should {
     "return a 302 and redirect to GG login" in {
-      when(QualifyingForSchemeControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithoutSession(QualifyingForSchemeControllerTest.show())(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -114,8 +116,7 @@ class QualifyingForSchemeControllerSpec extends UnitSpec with MockitoSugar with 
 
   "Posting to the QualifyingForSchemeController when authenticated" should {
     "redirect to 'What we'll ask you' page" in {
-      when(QualifyingForSchemeControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       submitWithSessionAndAuth(QualifyingForSchemeControllerTest.submit)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -163,8 +164,7 @@ class QualifyingForSchemeControllerSpec extends UnitSpec with MockitoSugar with 
 
   "Sending a submission to the QualifyingForSchemeController when NOT enrolled" should {
     "redirect to the Subscription Service" in {
-      when(QualifyingForSchemeControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       submitWithSessionAndAuth(QualifyingForSchemeControllerTest.submit)(
         result => {
           status(result) shouldBe SEE_OTHER

--- a/test/controllers/QualifyingForSchemeControllerSpec.scala
+++ b/test/controllers/QualifyingForSchemeControllerSpec.scala
@@ -18,13 +18,18 @@ package controllers
 
 import java.net.URLEncoder
 
-import auth.{MockAuthConnector, MockConfig}
+import auth.{Enrolment, Identifier, MockAuthConnector, MockConfig}
 import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.EnrolmentConnector
 import controllers.helpers.FakeRequestHelper
+import org.mockito.Matchers
+import org.mockito.Mockito._
 import play.api.test.Helpers._
 import uk.gov.hmrc.play.http.HeaderCarrier
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 import org.scalatest.mock.MockitoSugar
+
+import scala.concurrent.Future
 
 
 class QualifyingForSchemeControllerSpec extends UnitSpec with MockitoSugar with WithFakeApplication with FakeRequestHelper {
@@ -32,6 +37,7 @@ class QualifyingForSchemeControllerSpec extends UnitSpec with MockitoSugar with 
   object QualifyingForSchemeControllerTest extends QualifyingForSchemeController {
     override lazy val applicationConfig = FrontendAppConfig
     override lazy val authConnector = MockAuthConnector
+    override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
   implicit val hc = HeaderCarrier()
@@ -42,16 +48,20 @@ class QualifyingForSchemeControllerSpec extends UnitSpec with MockitoSugar with 
     }
   }
 
-  "Sending a GET request to QualifyingForSchemeController" should {
+  "Sending a GET request to QualifyingForSchemeController when authenticated and enrolled" should {
     "return a 200 OK" in {
+      when(QualifyingForSchemeControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       showWithSessionAndAuth(QualifyingForSchemeControllerTest.show)(
         result => status(result) shouldBe OK
       )
     }
   }
 
-  "Sending an Unauthenticated request with a session to NewGeographicalMarketController when authenticated" should {
+  "Sending an Unauthenticated request with a session to NewGeographicalMarketController when authenticated and enrolled" should {
     "return a 302 and redirect to GG login" in {
+      when(QualifyingForSchemeControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       showWithSessionWithoutAuth(QualifyingForSchemeControllerTest.show())(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -63,8 +73,23 @@ class QualifyingForSchemeControllerSpec extends UnitSpec with MockitoSugar with 
     }
   }
 
-  "Sending a request with no session to NewGeographicalMarketController when authenticated" should {
+  "Sending an Unauthenticated request with a session to NewGeographicalMarketController when authenticated and NOT enrolled" should {
+    "redirect to the Subscription Service" in {
+      when(QualifyingForSchemeControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(None))
+      submitWithSessionAndAuth(QualifyingForSchemeControllerTest.show())(
+        result => {
+          status(result) shouldBe SEE_OTHER
+          redirectLocation(result) shouldBe Some(FrontendAppConfig.subscriptionUrl)
+        }
+      )
+    }
+  }
+
+  "Sending a request with no session to NewGeographicalMarketController" should {
     "return a 302 and redirect to GG login" in {
+      when(QualifyingForSchemeControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       showWithoutSession(QualifyingForSchemeControllerTest.show())(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -76,7 +101,7 @@ class QualifyingForSchemeControllerSpec extends UnitSpec with MockitoSugar with 
     }
   }
 
-  "Sending a timed-out request to NewGeographicalMarketController when authenticated" should {
+  "Sending a timed-out request to NewGeographicalMarketController" should {
     "return a 302 and redirect to the timeout page" in {
       showWithTimeout(QualifyingForSchemeControllerTest.show())(
         result => {
@@ -89,6 +114,8 @@ class QualifyingForSchemeControllerSpec extends UnitSpec with MockitoSugar with 
 
   "Posting to the QualifyingForSchemeController when authenticated" should {
     "redirect to 'What we'll ask you' page" in {
+      when(QualifyingForSchemeControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       submitWithSessionAndAuth(QualifyingForSchemeControllerTest.submit)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -129,6 +156,19 @@ class QualifyingForSchemeControllerSpec extends UnitSpec with MockitoSugar with 
         result => {
           status(result) shouldBe SEE_OTHER
           redirectLocation(result) shouldBe Some(routes.TimeoutController.timeout().url)
+        }
+      )
+    }
+  }
+
+  "Sending a submission to the QualifyingForSchemeController when NOT enrolled" should {
+    "redirect to the Subscription Service" in {
+      when(QualifyingForSchemeControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(None))
+      submitWithSessionAndAuth(QualifyingForSchemeControllerTest.submit)(
+        result => {
+          status(result) shouldBe SEE_OTHER
+          redirectLocation(result) shouldBe Some(FrontendAppConfig.subscriptionUrl)
         }
       )
     }

--- a/test/controllers/ReviewPreviousSchemesControllerSpec.scala
+++ b/test/controllers/ReviewPreviousSchemesControllerSpec.scala
@@ -49,6 +49,12 @@ class ReviewPreviousSchemesControllerSpec extends UnitSpec with MockitoSugar wit
     override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
+  private def mockEnrolledRequest = when(ReviewPreviousSchemesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+
+  private def mockNotEnrolledRequest = when(ReviewPreviousSchemesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(None))
+
   val model = PreviousSchemeModel(
     Constants.PageInvestmentSchemeEisValue, 2356, None, None, Some(4), Some(12), Some(2009), Some(1))
   val model2 = PreviousSchemeModel(
@@ -87,8 +93,7 @@ class ReviewPreviousSchemesControllerSpec extends UnitSpec with MockitoSugar wit
     "return a 200 OK when a populated vector is returned from keystore" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[Vector[PreviousSchemeModel]](Matchers.any())(Matchers.any(), Matchers.any()))
               .thenReturn(Future.successful(Option(previousSchemeVectorList)))
-      when(ReviewPreviousSchemesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(ReviewPreviousSchemesControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -97,8 +102,7 @@ class ReviewPreviousSchemesControllerSpec extends UnitSpec with MockitoSugar wit
     "return a 200 OK when a empty vector is returned from keystore when authenticated and enrolled" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[Vector[PreviousSchemeModel]](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(emptyVectorList)))
-      when(ReviewPreviousSchemesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(ReviewPreviousSchemesControllerTest.show)(
 
         result => status(result) shouldBe OK
@@ -108,8 +112,7 @@ class ReviewPreviousSchemesControllerSpec extends UnitSpec with MockitoSugar wit
     "return a 200 OK when nothing is returned from keystore (recover block executed which creates empty vector) when authenticated and enrolled" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[Vector[PreviousSchemeModel]](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(ReviewPreviousSchemesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(ReviewPreviousSchemesControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -120,8 +123,7 @@ class ReviewPreviousSchemesControllerSpec extends UnitSpec with MockitoSugar wit
     "redirect to the Subscription Service" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[Vector[PreviousSchemeModel]](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(previousSchemeVectorList)))
-      when(ReviewPreviousSchemesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       showWithSessionAndAuth(ReviewPreviousSchemesControllerTest.show)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -172,8 +174,7 @@ class ReviewPreviousSchemesControllerSpec extends UnitSpec with MockitoSugar wit
     "redirect to 'Proposed Investment' page if table is not empty" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[Vector[PreviousSchemeModel]](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(previousSchemeVectorList)))
-      when(ReviewPreviousSchemesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       submitWithSessionAndAuth(ReviewPreviousSchemesControllerTest.submit)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -200,8 +201,7 @@ class ReviewPreviousSchemesControllerSpec extends UnitSpec with MockitoSugar wit
         (Matchers.eq(KeystoreKeys.previousSchemes))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(previousSchemeVectorList)))
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMapDeleted)
-      when(ReviewPreviousSchemesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       submitWithSessionAndAuth(ReviewPreviousSchemesControllerTest.remove(1))(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -217,8 +217,7 @@ class ReviewPreviousSchemesControllerSpec extends UnitSpec with MockitoSugar wit
         (Matchers.eq(KeystoreKeys.previousSchemes))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(previousSchemeVectorList)))
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
-      when(ReviewPreviousSchemesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       submitWithSessionAndAuth(ReviewPreviousSchemesControllerTest.remove(10))(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -232,8 +231,7 @@ class ReviewPreviousSchemesControllerSpec extends UnitSpec with MockitoSugar wit
         (Matchers.eq(KeystoreKeys.previousSchemes))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMapEmpty)
-      when(ReviewPreviousSchemesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       submitWithSessionAndAuth(ReviewPreviousSchemesControllerTest.remove(1))(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -246,8 +244,7 @@ class ReviewPreviousSchemesControllerSpec extends UnitSpec with MockitoSugar wit
   "Sending a GET request to ReviewPreviousSchemeController add method when authenticated and enrolled" should {
     "redirect to the previous investment scheme page" in {
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMapBackLink)
-      when(ReviewPreviousSchemesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       submitWithSessionAndAuth(ReviewPreviousSchemesControllerTest.add)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -260,8 +257,7 @@ class ReviewPreviousSchemesControllerSpec extends UnitSpec with MockitoSugar wit
   "Sending a GET request to ReviewPreviousSchemeController change method when authenticated and enrolled" should {
     "redirect to the previous investment scheme page" in {
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMapBackLink)
-      when(ReviewPreviousSchemesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       submitWithSessionAndAuth(ReviewPreviousSchemesControllerTest.change(testId))(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -309,8 +305,7 @@ class ReviewPreviousSchemesControllerSpec extends UnitSpec with MockitoSugar wit
 
   "Sending a submission to the NewGeographicalMarketController when NOT enrolled" should {
     "redirect to the Susbcription Service" in {
-      when(ReviewPreviousSchemesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       submitWithSessionAndAuth(ReviewPreviousSchemesControllerTest.submit)(
         result => {
           status(result) shouldBe SEE_OTHER

--- a/test/controllers/SubsidiariesControllerSpec.scala
+++ b/test/controllers/SubsidiariesControllerSpec.scala
@@ -48,6 +48,12 @@ class SubsidiariesControllerSpec extends UnitSpec with MockitoSugar with BeforeA
     override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
+  private def mockEnrolledRequest = when(SubsidiariesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+
+  private def mockNotEnrolledRequest = when(SubsidiariesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(None))
+
   val modelYes = SubsidiariesModel(Constants.StandardRadioButtonYesValue)
   val modelNo = SubsidiariesModel(Constants.StandardRadioButtonNoValue)
   val emptyModel = SubsidiariesModel("")
@@ -76,8 +82,7 @@ class SubsidiariesControllerSpec extends UnitSpec with MockitoSugar with BeforeA
         .thenReturn(Future.successful(None))
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesModel](Matchers.eq(KeystoreKeys.subsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiaries)))
-      when(SubsidiariesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(SubsidiariesControllerTest.show)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -94,8 +99,7 @@ class SubsidiariesControllerSpec extends UnitSpec with MockitoSugar with BeforeA
         .thenReturn(Future.successful(Option(routes.TenYearPlanController.show().toString())))
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesModel](Matchers.eq(KeystoreKeys.subsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiaries)))
-      when(SubsidiariesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(SubsidiariesControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -107,8 +111,7 @@ class SubsidiariesControllerSpec extends UnitSpec with MockitoSugar with BeforeA
         .thenReturn(Future.successful(Option(routes.PercentageStaffWithMastersController.show().toString())))
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesModel](Matchers.eq(KeystoreKeys.subsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(SubsidiariesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(SubsidiariesControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -122,8 +125,7 @@ class SubsidiariesControllerSpec extends UnitSpec with MockitoSugar with BeforeA
         .thenReturn(Future.successful(Option(routes.TenYearPlanController.show().toString())))
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesModel](Matchers.eq(KeystoreKeys.subsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiaries)))
-      when(SubsidiariesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       showWithSessionAndAuth(SubsidiariesControllerTest.show)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -176,8 +178,7 @@ class SubsidiariesControllerSpec extends UnitSpec with MockitoSugar with BeforeA
         (Matchers.eq(KeystoreKeys.backLinkSubsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.TenYearPlanController.show().toString())))
       when(mockKeyStoreConnector.saveFormData(Matchers.eq(KeystoreKeys.subsidiaries), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
-      when(SubsidiariesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "subsidiaries" -> Constants.StandardRadioButtonYesValue
       submitWithSessionAndAuth(SubsidiariesControllerTest.submit, formInput)(
         result => {
@@ -194,8 +195,7 @@ class SubsidiariesControllerSpec extends UnitSpec with MockitoSugar with BeforeA
         (Matchers.eq(KeystoreKeys.backLinkSubsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.TenYearPlanController.show().toString())))
       when(mockKeyStoreConnector.saveFormData(Matchers.eq(KeystoreKeys.subsidiaries), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
-      when(SubsidiariesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "subsidiaries" -> Constants.StandardRadioButtonNoValue
       submitWithSessionAndAuth(SubsidiariesControllerTest.submit, formInput)(
         result => {
@@ -211,8 +211,7 @@ class SubsidiariesControllerSpec extends UnitSpec with MockitoSugar with BeforeA
       when(mockKeyStoreConnector.fetchAndGetFormData[String]
         (Matchers.eq(KeystoreKeys.backLinkSubsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.TenYearPlanController.show().toString())))
-      when(SubsidiariesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "ownSubsidiaries" -> ""
       submitWithSessionAndAuth(SubsidiariesControllerTest.submit, formInput)(
         result => {
@@ -260,8 +259,7 @@ class SubsidiariesControllerSpec extends UnitSpec with MockitoSugar with BeforeA
 
   "Sending a submission to the SubsidiariesController when NOT enrolled" should {
     "redirect to the Subscription Service" in {
-      when(SubsidiariesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       submitWithSessionAndAuth(SubsidiariesControllerTest.submit)(
         result => {
           status(result) shouldBe SEE_OTHER

--- a/test/controllers/SubsidiariesControllerSpec.scala
+++ b/test/controllers/SubsidiariesControllerSpec.scala
@@ -18,10 +18,10 @@ package controllers
 
 import java.net.URLEncoder
 
-import auth.{MockAuthConnector, MockConfig}
+import auth.{Enrolment, Identifier, MockAuthConnector, MockConfig}
 import common.{Constants, KeystoreKeys}
 import config.{FrontendAppConfig, FrontendAuthConnector}
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.helpers.FakeRequestHelper
 import models._
 import org.mockito.Matchers
@@ -45,6 +45,7 @@ class SubsidiariesControllerSpec extends UnitSpec with MockitoSugar with BeforeA
     override lazy val applicationConfig = FrontendAppConfig
     override lazy val authConnector = MockAuthConnector
     val keyStoreConnector: KeystoreConnector = mockKeyStoreConnector
+    override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
   val modelYes = SubsidiariesModel(Constants.StandardRadioButtonYesValue)
@@ -68,13 +69,15 @@ class SubsidiariesControllerSpec extends UnitSpec with MockitoSugar with BeforeA
     }
   }
 
-  "Sending a GET request to SubsidiariesController without a valid back link from keystore when authenticated" should {
+  "Sending a GET request to SubsidiariesController without a valid back link from keystore when authenticated and enrolled" should {
     "redirect to the beginning of the flow" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[String]
         (Matchers.eq(KeystoreKeys.backLinkSubsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesModel](Matchers.eq(KeystoreKeys.subsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiaries)))
+      when(SubsidiariesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       showWithSessionAndAuth(SubsidiariesControllerTest.show)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -84,26 +87,48 @@ class SubsidiariesControllerSpec extends UnitSpec with MockitoSugar with BeforeA
     }
   }
 
-  "Sending a GET request to SubsidiariesController when authenticated" should {
+  "Sending a GET request to SubsidiariesController when authenticated and enrolled" should {
     "return a 200 when something is fetched from keystore" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[String]
         (Matchers.eq(KeystoreKeys.backLinkSubsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.TenYearPlanController.show().toString())))
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesModel](Matchers.eq(KeystoreKeys.subsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiaries)))
+      when(SubsidiariesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       showWithSessionAndAuth(SubsidiariesControllerTest.show)(
         result => status(result) shouldBe OK
       )
     }
 
-    "provide an empty model and return a 200 when nothing is fetched using keystore when authenticated" in {
+    "provide an empty model and return a 200 when nothing is fetched using keystore when authenticated and enrolled" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[String]
         (Matchers.eq(KeystoreKeys.backLinkSubsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.PercentageStaffWithMastersController.show().toString())))
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesModel](Matchers.eq(KeystoreKeys.subsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
+      when(SubsidiariesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       showWithSessionAndAuth(SubsidiariesControllerTest.show)(
         result => status(result) shouldBe OK
+      )
+    }
+  }
+
+  "Sending a GET request to SubsidiariesController when authenticated and NOT enrolled" should {
+    "redirect to the Subscription Service" in {
+      when(mockKeyStoreConnector.fetchAndGetFormData[String]
+        (Matchers.eq(KeystoreKeys.backLinkSubsidiaries))(Matchers.any(), Matchers.any()))
+        .thenReturn(Future.successful(Option(routes.TenYearPlanController.show().toString())))
+      when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesModel](Matchers.eq(KeystoreKeys.subsidiaries))(Matchers.any(), Matchers.any()))
+        .thenReturn(Future.successful(Option(keyStoreSavedSubsidiaries)))
+      when(SubsidiariesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(None))
+      showWithSessionAndAuth(SubsidiariesControllerTest.show)(
+        result => {
+          status(result) shouldBe SEE_OTHER
+          redirectLocation(result) shouldBe Some(FrontendAppConfig.subscriptionUrl)
+        }
       )
     }
   }
@@ -145,12 +170,14 @@ class SubsidiariesControllerSpec extends UnitSpec with MockitoSugar with BeforeA
     }
   }
 
-  "Sending a valid 'Yes' form submit to the SubsidiariesController when authenticated" should {
+  "Sending a valid 'Yes' form submit to the SubsidiariesController when authenticated and enrolled" should {
     "redirect to the previous investment before page" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[String]
         (Matchers.eq(KeystoreKeys.backLinkSubsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.TenYearPlanController.show().toString())))
       when(mockKeyStoreConnector.saveFormData(Matchers.eq(KeystoreKeys.subsidiaries), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
+      when(SubsidiariesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       val formInput = "subsidiaries" -> Constants.StandardRadioButtonYesValue
       submitWithSessionAndAuth(SubsidiariesControllerTest.submit, formInput)(
         result => {
@@ -161,12 +188,14 @@ class SubsidiariesControllerSpec extends UnitSpec with MockitoSugar with BeforeA
     }
   }
 
-  "Sending a valid 'No' form submit to the SubsidiariesController when authenticated" should {
+  "Sending a valid 'No' form submit to the SubsidiariesController when authenticated and enrolled" should {
     "redirect to the previous investment before page" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[String]
         (Matchers.eq(KeystoreKeys.backLinkSubsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.TenYearPlanController.show().toString())))
       when(mockKeyStoreConnector.saveFormData(Matchers.eq(KeystoreKeys.subsidiaries), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
+      when(SubsidiariesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       val formInput = "subsidiaries" -> Constants.StandardRadioButtonNoValue
       submitWithSessionAndAuth(SubsidiariesControllerTest.submit, formInput)(
         result => {
@@ -177,11 +206,13 @@ class SubsidiariesControllerSpec extends UnitSpec with MockitoSugar with BeforeA
     }
   }
 
-  "Sending an invalid form submission with validation errors to the SubsidiariesController when authenticated" should {
+  "Sending an invalid form submission with validation errors to the SubsidiariesController when authenticated and enrolled" should {
     "redirect to itself with errors" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[String]
         (Matchers.eq(KeystoreKeys.backLinkSubsidiaries))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.TenYearPlanController.show().toString())))
+      when(SubsidiariesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       val formInput = "ownSubsidiaries" -> ""
       submitWithSessionAndAuth(SubsidiariesControllerTest.submit, formInput)(
         result => {
@@ -222,6 +253,19 @@ class SubsidiariesControllerSpec extends UnitSpec with MockitoSugar with BeforeA
         result => {
           status(result) shouldBe SEE_OTHER
           redirectLocation(result) shouldBe Some(routes.TimeoutController.timeout().url)
+        }
+      )
+    }
+  }
+
+  "Sending a submission to the SubsidiariesController when NOT enrolled" should {
+    "redirect to the Subscription Service" in {
+      when(SubsidiariesControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(None))
+      submitWithSessionAndAuth(SubsidiariesControllerTest.submit)(
+        result => {
+          status(result) shouldBe SEE_OTHER
+          redirectLocation(result) shouldBe Some(FrontendAppConfig.subscriptionUrl)
         }
       )
     }

--- a/test/controllers/SubsidiariesNinetyOwnedControllerSpec.scala
+++ b/test/controllers/SubsidiariesNinetyOwnedControllerSpec.scala
@@ -18,11 +18,11 @@ package controllers
 
 import java.net.URLEncoder
 
-import auth.{MockAuthConnector, MockConfig}
+import auth.{Enrolment, Identifier, MockAuthConnector, MockConfig}
 import config.{FrontendAppConfig, FrontendAuthConnector}
 import models.SubsidiariesNinetyOwnedModel
 import common.Constants
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.helpers.FakeRequestHelper
 import org.mockito.Matchers
 import org.mockito.Mockito._
@@ -46,6 +46,7 @@ class SubsidiariesNinetyOwnedControllerSpec extends UnitSpec with MockitoSugar w
     override lazy val applicationConfig = FrontendAppConfig
     override lazy val authConnector = MockAuthConnector
     val keyStoreConnector: KeystoreConnector = mockKeyStoreConnector
+    override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
   val model = SubsidiariesNinetyOwnedModel(Constants.StandardRadioButtonYesValue)
@@ -67,11 +68,13 @@ class SubsidiariesNinetyOwnedControllerSpec extends UnitSpec with MockitoSugar w
     }
   }
 
-  "Sending a GET request to SubsidiariesNinetyOwnedController when authenticated" should {
+  "Sending a GET request to SubsidiariesNinetyOwnedController when authenticated and enrolled" should {
     "return a 200 when something is fetched from keystore" in {
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesNinetyOwnedModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesNinetyOwned)))
+      when(SubsidiariesNinetyOwnedControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       showWithSessionAndAuth(SubsidiariesNinetyOwnedControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -81,8 +84,26 @@ class SubsidiariesNinetyOwnedControllerSpec extends UnitSpec with MockitoSugar w
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesNinetyOwnedModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
+      when(SubsidiariesNinetyOwnedControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       showWithSessionAndAuth(SubsidiariesNinetyOwnedControllerTest.show)(
         result => status(result) shouldBe OK
+      )
+    }
+  }
+
+  "Sending a GET request to SubsidiariesNinetyOwnedController when authenticated and NOT enrolled" should {
+    "redirect to the Subscription Service" in {
+      when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
+      when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesNinetyOwnedModel](Matchers.any())(Matchers.any(), Matchers.any()))
+        .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesNinetyOwned)))
+      when(SubsidiariesNinetyOwnedControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(None))
+      showWithSessionAndAuth(SubsidiariesNinetyOwnedControllerTest.show)(
+        result => {
+          status(result) shouldBe SEE_OTHER
+          redirectLocation(result) shouldBe Some(FrontendAppConfig.subscriptionUrl)
+        }
       )
     }
   }
@@ -124,9 +145,10 @@ class SubsidiariesNinetyOwnedControllerSpec extends UnitSpec with MockitoSugar w
     }
   }
 
-  "Sending a valid form submission to the SubsidiariesNinetyOwnedController when authenticated" should {
+  "Sending a valid form submission to the SubsidiariesNinetyOwnedController when authenticated and enrolled" should {
     "redirect to the how-plan-to-use-investment page" in {
-
+      when(SubsidiariesNinetyOwnedControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       val formInput = "ownNinetyPercent" -> Constants.StandardRadioButtonYesValue
       submitWithSessionAndAuth(SubsidiariesNinetyOwnedControllerTest.submit, formInput)(
         result => {
@@ -137,9 +159,10 @@ class SubsidiariesNinetyOwnedControllerSpec extends UnitSpec with MockitoSugar w
     }
   }
 
-  "Sending an empty invalid form submission with validation errors to the SubsidiariesNinetyOwnedController when authenticated" should {
+  "Sending an empty invalid form submission with validation errors to the SubsidiariesNinetyOwnedController when authenticated and enrolled" should {
     "redirect to itself" in {
-
+      when(SubsidiariesNinetyOwnedControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       val formInput = "ownNinetyPercent" -> ""
       submitWithSessionAndAuth(SubsidiariesNinetyOwnedControllerTest.submit, formInput)(
         result => {
@@ -180,6 +203,19 @@ class SubsidiariesNinetyOwnedControllerSpec extends UnitSpec with MockitoSugar w
         result => {
           status(result) shouldBe SEE_OTHER
           redirectLocation(result) shouldBe Some(routes.TimeoutController.timeout().url)
+        }
+      )
+    }
+  }
+
+  "Sending a submission to the SubsidiariesNinetyOwnedController when NOT enrolled" should {
+    "redirect to the Subscription Service" in {
+      when(SubsidiariesNinetyOwnedControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(None))
+      submitWithSessionAndAuth(SubsidiariesNinetyOwnedControllerTest.submit)(
+        result => {
+          status(result) shouldBe SEE_OTHER
+          redirectLocation(result) shouldBe Some(FrontendAppConfig.subscriptionUrl)
         }
       )
     }

--- a/test/controllers/SubsidiariesNinetyOwnedControllerSpec.scala
+++ b/test/controllers/SubsidiariesNinetyOwnedControllerSpec.scala
@@ -49,6 +49,12 @@ class SubsidiariesNinetyOwnedControllerSpec extends UnitSpec with MockitoSugar w
     override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
+  private def mockEnrolledRequest = when(SubsidiariesNinetyOwnedControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+
+  private def mockNotEnrolledRequest = when(SubsidiariesNinetyOwnedControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(None))
+
   val model = SubsidiariesNinetyOwnedModel(Constants.StandardRadioButtonYesValue)
   val cacheMap: CacheMap = CacheMap("", Map("" -> Json.toJson(model)))
   val keyStoreSavedSubsidiariesNinetyOwned = SubsidiariesNinetyOwnedModel(Constants.StandardRadioButtonYesValue)
@@ -73,8 +79,7 @@ class SubsidiariesNinetyOwnedControllerSpec extends UnitSpec with MockitoSugar w
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesNinetyOwnedModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesNinetyOwned)))
-      when(SubsidiariesNinetyOwnedControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(SubsidiariesNinetyOwnedControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -84,8 +89,7 @@ class SubsidiariesNinetyOwnedControllerSpec extends UnitSpec with MockitoSugar w
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesNinetyOwnedModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(SubsidiariesNinetyOwnedControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(SubsidiariesNinetyOwnedControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -97,8 +101,7 @@ class SubsidiariesNinetyOwnedControllerSpec extends UnitSpec with MockitoSugar w
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesNinetyOwnedModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesNinetyOwned)))
-      when(SubsidiariesNinetyOwnedControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       showWithSessionAndAuth(SubsidiariesNinetyOwnedControllerTest.show)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -147,8 +150,7 @@ class SubsidiariesNinetyOwnedControllerSpec extends UnitSpec with MockitoSugar w
 
   "Sending a valid form submission to the SubsidiariesNinetyOwnedController when authenticated and enrolled" should {
     "redirect to the how-plan-to-use-investment page" in {
-      when(SubsidiariesNinetyOwnedControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "ownNinetyPercent" -> Constants.StandardRadioButtonYesValue
       submitWithSessionAndAuth(SubsidiariesNinetyOwnedControllerTest.submit, formInput)(
         result => {
@@ -161,8 +163,7 @@ class SubsidiariesNinetyOwnedControllerSpec extends UnitSpec with MockitoSugar w
 
   "Sending an empty invalid form submission with validation errors to the SubsidiariesNinetyOwnedController when authenticated and enrolled" should {
     "redirect to itself" in {
-      when(SubsidiariesNinetyOwnedControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "ownNinetyPercent" -> ""
       submitWithSessionAndAuth(SubsidiariesNinetyOwnedControllerTest.submit, formInput)(
         result => {
@@ -210,8 +211,7 @@ class SubsidiariesNinetyOwnedControllerSpec extends UnitSpec with MockitoSugar w
 
   "Sending a submission to the SubsidiariesNinetyOwnedController when NOT enrolled" should {
     "redirect to the Subscription Service" in {
-      when(SubsidiariesNinetyOwnedControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       submitWithSessionAndAuth(SubsidiariesNinetyOwnedControllerTest.submit)(
         result => {
           status(result) shouldBe SEE_OTHER

--- a/test/controllers/SubsidiariesSpendingInvestmentControllerSpec.scala
+++ b/test/controllers/SubsidiariesSpendingInvestmentControllerSpec.scala
@@ -54,6 +54,12 @@ class SubsidiariesSpendingInvestmentControllerSpec extends UnitSpec with Mockito
   val cacheMap: CacheMap = CacheMap("", Map("" -> Json.toJson(modelYes)))
   val keyStoreSavedSubsidiariesSpendingInvestment = SubsidiariesSpendingInvestmentModel(Constants.StandardRadioButtonYesValue)
 
+  private def mockEnrolledRequest = when(SubsidiariesSpendingInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+
+  private def mockNotEnrolledRequest = when(SubsidiariesSpendingInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(None))
+
   implicit val hc = HeaderCarrier()
 
   override def beforeEach() {
@@ -75,8 +81,7 @@ class SubsidiariesSpendingInvestmentControllerSpec extends UnitSpec with Mockito
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesSpendingInvestment)))
       when(mockKeyStoreConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkSubSpendingInvestment))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.WhatWillUseForController.show().toString())))
-      when(SubsidiariesSpendingInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(SubsidiariesSpendingInvestmentControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -87,8 +92,7 @@ class SubsidiariesSpendingInvestmentControllerSpec extends UnitSpec with Mockito
         .thenReturn(Future.successful(Option(routes.WhatWillUseForController.show().toString())))
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesSpendingInvestmentModel](Matchers.eq(KeystoreKeys.subsidiariesSpendingInvestment))
         (Matchers.any(), Matchers.any())).thenReturn(Future.successful(None))
-      when(SubsidiariesSpendingInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(SubsidiariesSpendingInvestmentControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -97,8 +101,7 @@ class SubsidiariesSpendingInvestmentControllerSpec extends UnitSpec with Mockito
     "provide an empty model and return a 300 when no back link is fetched using keystore when authenticated and enrolled" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkSubSpendingInvestment))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(SubsidiariesSpendingInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       showWithSessionAndAuth(SubsidiariesSpendingInvestmentControllerTest.show)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -114,8 +117,7 @@ class SubsidiariesSpendingInvestmentControllerSpec extends UnitSpec with Mockito
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesSpendingInvestment)))
       when(mockKeyStoreConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkSubSpendingInvestment))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.WhatWillUseForController.show().toString())))
-      when(SubsidiariesSpendingInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       showWithSessionAndAuth(SubsidiariesSpendingInvestmentControllerTest.show)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -164,8 +166,7 @@ class SubsidiariesSpendingInvestmentControllerSpec extends UnitSpec with Mockito
 
   "Sending a valid 'Yes' form submit to the SubsidiariesSpendingInvestmentController when authenticated and enrolled" should {
     "redirect to the subsidiaries-ninety-percent-owned page" in {
-      when(SubsidiariesSpendingInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "subSpendingInvestment" -> Constants.StandardRadioButtonYesValue
       submitWithSessionAndAuth(SubsidiariesSpendingInvestmentControllerTest.submit, formInput)(
         result => {
@@ -178,8 +179,7 @@ class SubsidiariesSpendingInvestmentControllerSpec extends UnitSpec with Mockito
 
   "Sending a valid 'No' form submit to the SubsidiariesSpendingInvestmentController when authenticated and enrolled" should {
     "redirect to the how-plan-to-use-investment page" in {
-      when(SubsidiariesSpendingInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "subSpendingInvestment" -> Constants.StandardRadioButtonNoValue
       submitWithSessionAndAuth(SubsidiariesSpendingInvestmentControllerTest.submit, formInput)(
         result => {
@@ -194,8 +194,7 @@ class SubsidiariesSpendingInvestmentControllerSpec extends UnitSpec with Mockito
     "redirect to the subsidiaries-ninety-percent-owned page" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkSubSpendingInvestment))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
-      when(SubsidiariesSpendingInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "subSpendingInvestment" -> ""
       submitWithSessionAndAuth(SubsidiariesSpendingInvestmentControllerTest.submit, formInput)(
         result => {
@@ -210,8 +209,7 @@ class SubsidiariesSpendingInvestmentControllerSpec extends UnitSpec with Mockito
     "redirect to itself with errors" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkSubSpendingInvestment))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.WhatWillUseForController.show().toString())))
-      when(SubsidiariesSpendingInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+      mockEnrolledRequest
       val formInput = "subSpendingInvestment" -> ""
       submitWithSessionAndAuth(SubsidiariesSpendingInvestmentControllerTest.submit, formInput)(
         result => {
@@ -259,8 +257,7 @@ class SubsidiariesSpendingInvestmentControllerSpec extends UnitSpec with Mockito
 
   "Sending a submission to the SubsidiariesSpendingInvestmentController when NOT enrolled" should {
     "redirect to the Subscription Service" in {
-      when(SubsidiariesSpendingInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
-        .thenReturn(Future.successful(None))
+      mockNotEnrolledRequest
       submitWithSessionAndAuth(SubsidiariesSpendingInvestmentControllerTest.submit)(
         result => {
           status(result) shouldBe SEE_OTHER

--- a/test/controllers/SubsidiariesSpendingInvestmentControllerSpec.scala
+++ b/test/controllers/SubsidiariesSpendingInvestmentControllerSpec.scala
@@ -18,10 +18,10 @@ package controllers
 
 import java.net.URLEncoder
 
-import auth.{MockAuthConnector, MockConfig}
+import auth.{Enrolment, Identifier, MockAuthConnector, MockConfig}
 import common.{Constants, KeystoreKeys}
 import config.{FrontendAppConfig, FrontendAuthConnector}
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.helpers.FakeRequestHelper
 import models._
 import org.mockito.Matchers
@@ -45,6 +45,7 @@ class SubsidiariesSpendingInvestmentControllerSpec extends UnitSpec with Mockito
     override lazy val applicationConfig = FrontendAppConfig
     override lazy val authConnector = MockAuthConnector
     val keyStoreConnector: KeystoreConnector = mockKeyStoreConnector
+    override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
 
   val modelYes = SubsidiariesSpendingInvestmentModel(Constants.StandardRadioButtonYesValue)
@@ -68,34 +69,57 @@ class SubsidiariesSpendingInvestmentControllerSpec extends UnitSpec with Mockito
     }
   }
 
-  "Sending a GET request to SubsidiariesSpendingInvestmentController when authenticated" should {
+  "Sending a GET request to SubsidiariesSpendingInvestmentController when authenticated and enrolled" should {
     "return a 200 when something is fetched from keystore" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesSpendingInvestmentModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesSpendingInvestment)))
       when(mockKeyStoreConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkSubSpendingInvestment))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.WhatWillUseForController.show().toString())))
+      when(SubsidiariesSpendingInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       showWithSessionAndAuth(SubsidiariesSpendingInvestmentControllerTest.show)(
         result => status(result) shouldBe OK
       )
     }
 
-    "provide an empty model and return a 200 when nothing is fetched using keystore when authenticated" in {
+    "provide an empty model and return a 200 when nothing is fetched using keystore when authenticated and enrolled" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkSubSpendingInvestment))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.WhatWillUseForController.show().toString())))
       when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesSpendingInvestmentModel](Matchers.eq(KeystoreKeys.subsidiariesSpendingInvestment))
         (Matchers.any(), Matchers.any())).thenReturn(Future.successful(None))
+      when(SubsidiariesSpendingInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       showWithSessionAndAuth(SubsidiariesSpendingInvestmentControllerTest.show)(
         result => status(result) shouldBe OK
       )
     }
 
-    "provide an empty model and return a 300 when no back link is fetched using keystore when authenticated" in {
+    "provide an empty model and return a 300 when no back link is fetched using keystore when authenticated and enrolled" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkSubSpendingInvestment))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
+      when(SubsidiariesSpendingInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       showWithSessionAndAuth(SubsidiariesSpendingInvestmentControllerTest.show)(
         result => {
           status(result) shouldBe SEE_OTHER
           redirectLocation(result) shouldBe Some("/investment-tax-relief/investment-purpose")
+        }
+      )
+    }
+  }
+
+  "Sending a GET request to SubsidiariesSpendingInvestmentController when authenticated and NOT enrolled" should {
+    "return a 200 when something is fetched from keystore" in {
+      when(mockKeyStoreConnector.fetchAndGetFormData[SubsidiariesSpendingInvestmentModel](Matchers.any())(Matchers.any(), Matchers.any()))
+        .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesSpendingInvestment)))
+      when(mockKeyStoreConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkSubSpendingInvestment))(Matchers.any(), Matchers.any()))
+        .thenReturn(Future.successful(Option(routes.WhatWillUseForController.show().toString())))
+      when(SubsidiariesSpendingInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(None))
+      showWithSessionAndAuth(SubsidiariesSpendingInvestmentControllerTest.show)(
+        result => {
+          status(result) shouldBe SEE_OTHER
+          redirectLocation(result) shouldBe Some(FrontendAppConfig.subscriptionUrl)
         }
       )
     }
@@ -138,8 +162,10 @@ class SubsidiariesSpendingInvestmentControllerSpec extends UnitSpec with Mockito
     }
   }
 
-  "Sending a valid 'Yes' form submit to the SubsidiariesSpendingInvestmentController when authenticated" should {
+  "Sending a valid 'Yes' form submit to the SubsidiariesSpendingInvestmentController when authenticated and enrolled" should {
     "redirect to the subsidiaries-ninety-percent-owned page" in {
+      when(SubsidiariesSpendingInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       val formInput = "subSpendingInvestment" -> Constants.StandardRadioButtonYesValue
       submitWithSessionAndAuth(SubsidiariesSpendingInvestmentControllerTest.submit, formInput)(
         result => {
@@ -150,8 +176,10 @@ class SubsidiariesSpendingInvestmentControllerSpec extends UnitSpec with Mockito
     }
   }
 
-  "Sending a valid 'No' form submit to the SubsidiariesSpendingInvestmentController when authenticated" should {
+  "Sending a valid 'No' form submit to the SubsidiariesSpendingInvestmentController when authenticated and enrolled" should {
     "redirect to the how-plan-to-use-investment page" in {
+      when(SubsidiariesSpendingInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       val formInput = "subSpendingInvestment" -> Constants.StandardRadioButtonNoValue
       submitWithSessionAndAuth(SubsidiariesSpendingInvestmentControllerTest.submit, formInput)(
         result => {
@@ -162,10 +190,12 @@ class SubsidiariesSpendingInvestmentControllerSpec extends UnitSpec with Mockito
     }
   }
 
-  "Sending a invalid form submit to the SubsidiariesSpendingInvestmentController with no back link when authenticated" should {
+  "Sending a invalid form submit to the SubsidiariesSpendingInvestmentController with no back link when authenticated and enrolled" should {
     "redirect to the subsidiaries-ninety-percent-owned page" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkSubSpendingInvestment))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
+      when(SubsidiariesSpendingInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       val formInput = "subSpendingInvestment" -> ""
       submitWithSessionAndAuth(SubsidiariesSpendingInvestmentControllerTest.submit, formInput)(
         result => {
@@ -176,10 +206,12 @@ class SubsidiariesSpendingInvestmentControllerSpec extends UnitSpec with Mockito
     }
   }
 
-  "Sending an invalid form submission with validation errors to the SubsidiariesSpendingInvestmentController when authenticated" should {
+  "Sending an invalid form submission with validation errors to the SubsidiariesSpendingInvestmentController when authenticated and enrolled" should {
     "redirect to itself with errors" in {
       when(mockKeyStoreConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkSubSpendingInvestment))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(routes.WhatWillUseForController.show().toString())))
+      when(SubsidiariesSpendingInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
       val formInput = "subSpendingInvestment" -> ""
       submitWithSessionAndAuth(SubsidiariesSpendingInvestmentControllerTest.submit, formInput)(
         result => {
@@ -220,6 +252,19 @@ class SubsidiariesSpendingInvestmentControllerSpec extends UnitSpec with Mockito
         result => {
           status(result) shouldBe SEE_OTHER
           redirectLocation(result) shouldBe Some(routes.TimeoutController.timeout().url)
+        }
+      )
+    }
+  }
+
+  "Sending a submission to the SubsidiariesSpendingInvestmentController when NOT enrolled" should {
+    "redirect to the Subscription Service" in {
+      when(SubsidiariesSpendingInvestmentControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(None))
+      submitWithSessionAndAuth(SubsidiariesSpendingInvestmentControllerTest.submit)(
+        result => {
+          status(result) shouldBe SEE_OTHER
+          redirectLocation(result) shouldBe Some(FrontendAppConfig.subscriptionUrl)
         }
       )
     }

--- a/test/controllers/WhatWillUseForControllerSpec.scala
+++ b/test/controllers/WhatWillUseForControllerSpec.scala
@@ -36,11 +36,11 @@ import java.net.URLEncoder
 import java.time.ZoneId
 import java.util.{Date, UUID}
 
-import auth.{MockAuthConnector, MockConfig}
+import auth.{Enrolment, Identifier, MockAuthConnector, MockConfig}
 import builders.SessionBuilder
 import common.{Constants, KeystoreKeys}
 import config.{FrontendAppConfig, FrontendAuthConnector}
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.helpers.FakeRequestHelper
 import models._
 import org.mockito.Matchers
@@ -66,7 +66,14 @@ class WhatWillUseForControllerSpec extends UnitSpec with MockitoSugar with Befor
     override lazy val applicationConfig = FrontendAppConfig
     override lazy val authConnector = MockAuthConnector
     val keyStoreConnector: KeystoreConnector = mockKeyStoreConnector
+    override lazy val enrolmentConnector = mock[EnrolmentConnector]
   }
+
+  private def mockEnrolledRequest = when(WhatWillUseForControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG",Seq(Identifier("TavcReference","1234")),"Activated"))))
+
+  private def mockNotEnrolledRequest = when(WhatWillUseForControllerTest.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+    .thenReturn(Future.successful(None))
 
 //  //Gary TEST SCENARIOS
 //  /*
@@ -258,11 +265,12 @@ class WhatWillUseForControllerSpec extends UnitSpec with MockitoSugar with Befor
     }
   }
 
-  "Sending a GET request to WhatWillUseForController" should {
+  "Sending a GET request to WhatWillUseForController when authenticated and enrolled" should {
     "return a 200 when something is fetched from keystore" in {
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[WhatWillUseForModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedWhatWillUseForBusiness)))
+      mockEnrolledRequest
       showWithSessionAndAuth(WhatWillUseForControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -272,6 +280,7 @@ class WhatWillUseForControllerSpec extends UnitSpec with MockitoSugar with Befor
       when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
       when(mockKeyStoreConnector.fetchAndGetFormData[WhatWillUseForModel](Matchers.any())(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
+      mockEnrolledRequest
       showWithSessionAndAuth(WhatWillUseForControllerTest.show)(
         result => status(result) shouldBe OK
       )
@@ -294,6 +303,7 @@ class WhatWillUseForControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesYes)))
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.eq(KeystoreKeys.dateOfIncorporation))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedDOI3YearsLessOneDay)))
+      mockEnrolledRequest
       submitWithSessionAndAuth(WhatWillUseForControllerTest.submit,
         "whatWillUseFor" -> "Research and Development")(
         result => {
@@ -319,6 +329,7 @@ class WhatWillUseForControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesYes)))
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.eq(KeystoreKeys.dateOfIncorporation))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedDOI3YearsLessOneDay)))
+      mockEnrolledRequest
       submitWithSessionAndAuth(WhatWillUseForControllerTest.submit,
         "whatWillUseFor" -> "Research and Development")(
         result => {
@@ -343,6 +354,7 @@ class WhatWillUseForControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesYes)))
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.eq(KeystoreKeys.dateOfIncorporation))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedDOI3YearsLessOneDay)))
+      mockEnrolledRequest
       submitWithSessionAndAuth(WhatWillUseForControllerTest.submit,
         "whatWillUseFor" -> "Research and Development")(
         result => {
@@ -367,6 +379,7 @@ class WhatWillUseForControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesYes)))
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.eq(KeystoreKeys.dateOfIncorporation))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedDOI3YearsLessOneDay)))
+      mockEnrolledRequest
       submitWithSessionAndAuth(WhatWillUseForControllerTest.submit,
         "whatWillUseFor" -> "Research and Development")(
         result => {
@@ -391,6 +404,7 @@ class WhatWillUseForControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesYes)))
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.eq(KeystoreKeys.dateOfIncorporation))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedDOI3Years)))
+      mockEnrolledRequest
       submitWithSessionAndAuth(WhatWillUseForControllerTest.submit,
         "whatWillUseFor" -> "Research and Development")(
         result => {
@@ -415,6 +429,7 @@ class WhatWillUseForControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesYes)))
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.eq(KeystoreKeys.dateOfIncorporation))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedDOI3Years)))
+      mockEnrolledRequest
       submitWithSessionAndAuth(WhatWillUseForControllerTest.submit,
         "whatWillUseFor" -> "Research and Development")(
         result => {
@@ -439,6 +454,7 @@ class WhatWillUseForControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesNo)))
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.eq(KeystoreKeys.dateOfIncorporation))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedDOI3YearsLessOneDay)))
+      mockEnrolledRequest
       submitWithSessionAndAuth(WhatWillUseForControllerTest.submit,
         "whatWillUseFor" -> "Research and Development")(
         result => {
@@ -463,6 +479,7 @@ class WhatWillUseForControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesNo)))
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.eq(KeystoreKeys.dateOfIncorporation))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedDOI3YearsOneDay)))
+      mockEnrolledRequest
       submitWithSessionAndAuth(WhatWillUseForControllerTest.submit,
         "whatWillUseFor" -> "Research and Development")(
         result => {
@@ -487,6 +504,7 @@ class WhatWillUseForControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesNo)))
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.eq(KeystoreKeys.dateOfIncorporation))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedDOI3Years)))
+      mockEnrolledRequest
       submitWithSessionAndAuth(WhatWillUseForControllerTest.submit,
         "whatWillUseFor" -> "Research and Development")(
         result => {
@@ -511,6 +529,7 @@ class WhatWillUseForControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesNo)))
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.eq(KeystoreKeys.dateOfIncorporation))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedDOI3Years)))
+      mockEnrolledRequest
       submitWithSessionAndAuth(WhatWillUseForControllerTest.submit,
         "whatWillUseFor" -> "Research and Development")(
         result => {
@@ -535,6 +554,7 @@ class WhatWillUseForControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesYes)))
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.eq(KeystoreKeys.dateOfIncorporation))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedDOI3Years)))
+      mockEnrolledRequest
       submitWithSessionAndAuth(WhatWillUseForControllerTest.submit,
         "whatWillUseFor" -> "Research and Development")(
         result => {
@@ -559,6 +579,7 @@ class WhatWillUseForControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesNo)))
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.eq(KeystoreKeys.dateOfIncorporation))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedDOI3Years)))
+      mockEnrolledRequest
       submitWithSessionAndAuth(WhatWillUseForControllerTest.submit,
         "whatWillUseFor" -> "Research and Development")(
         result => {
@@ -583,6 +604,7 @@ class WhatWillUseForControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesNo)))
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.eq(KeystoreKeys.dateOfIncorporation))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedDOI3YearsLessOneDay)))
+      mockEnrolledRequest
       submitWithSessionAndAuth(WhatWillUseForControllerTest.submit,
         "whatWillUseFor" -> "Research and Development")(
         result => {
@@ -607,6 +629,7 @@ class WhatWillUseForControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesYes)))
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.eq(KeystoreKeys.dateOfIncorporation))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedDOI3YearsLessOneDay)))
+      mockEnrolledRequest
       submitWithSessionAndAuth(WhatWillUseForControllerTest.submit,
         "whatWillUseFor" -> "Research and Development")(
         result => {
@@ -630,6 +653,7 @@ class WhatWillUseForControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(None))
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.eq(KeystoreKeys.dateOfIncorporation))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedDOI3Years)))
+      mockEnrolledRequest
       submitWithSessionAndAuth(WhatWillUseForControllerTest.submit,
         "whatWillUseFor" -> "Research and Development")(
         result => {
@@ -653,6 +677,7 @@ class WhatWillUseForControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesYes)))
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.eq(KeystoreKeys.dateOfIncorporation))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedDOI3YearsLessOneDay)))
+      mockEnrolledRequest
       submitWithSessionAndAuth(WhatWillUseForControllerTest.submit,
         "whatWillUseFor" -> "Research and Development")(
         result => {
@@ -677,6 +702,7 @@ class WhatWillUseForControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesYes)))
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.eq(KeystoreKeys.dateOfIncorporation))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedDOI3Years)))
+      mockEnrolledRequest
       submitWithSessionAndAuth(WhatWillUseForControllerTest.submit,
         "whatWillUseFor" -> "Research and Development")(
         result => {
@@ -700,6 +726,7 @@ class WhatWillUseForControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(None))
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.eq(KeystoreKeys.dateOfIncorporation))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
+      mockEnrolledRequest
       submitWithSessionAndAuth(WhatWillUseForControllerTest.submit,
         "whatWillUseFor" -> "Research and Development")(
         result => {
@@ -723,6 +750,7 @@ class WhatWillUseForControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(None))
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.eq(KeystoreKeys.dateOfIncorporation))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(None))
+      mockEnrolledRequest
       submitWithSessionAndAuth(WhatWillUseForControllerTest.submit,
         "whatWillUseFor" -> "Research and Development")(
         result => {
@@ -745,6 +773,7 @@ class WhatWillUseForControllerSpec extends UnitSpec with MockitoSugar with Befor
         .thenReturn(Future.successful(Option(keyStoreSavedSubsidiariesYes)))
       when(mockKeyStoreConnector.fetchAndGetFormData[DateOfIncorporationModel](Matchers.eq(KeystoreKeys.dateOfIncorporation))(Matchers.any(), Matchers.any()))
         .thenReturn(Future.successful(Option(keyStoreSavedDOI3Years)))
+      mockEnrolledRequest
       submitWithSessionAndAuth(WhatWillUseForControllerTest.submit,
         "whatWillUseFor" -> "Research and Development")(
         result => {
@@ -758,6 +787,7 @@ class WhatWillUseForControllerSpec extends UnitSpec with MockitoSugar with Befor
 
   "Sending an invalid form submission with validation errors to the WhatWillUseForController" should {
     "redirect to itself" in {
+      mockEnrolledRequest
       submitWithSessionAndAuth(WhatWillUseForControllerTest.submit,
         "whatWillUseFor" -> "")(
         result => {
@@ -801,6 +831,19 @@ class WhatWillUseForControllerSpec extends UnitSpec with MockitoSugar with Befor
     }
   }
 
+  "Sending a request to WhatWillUseForController when NOT enrolled" should {
+
+    "return a 303 in" in {
+      mockNotEnrolledRequest
+      status(WhatWillUseForControllerTest.show(authorisedFakeRequest)) shouldBe SEE_OTHER
+    }
+
+    s"should redirect to the Subscription Service" in {
+      mockNotEnrolledRequest
+      redirectLocation(WhatWillUseForControllerTest.show(authorisedFakeRequest)) shouldBe Some(FrontendAppConfig.subscriptionUrl)
+    }
+  }
+
   "Sending a submission to the WhatWillUseForController when not authenticated" should {
 
     "redirect to the GG login page when having a session but not authenticated" in {
@@ -835,6 +878,17 @@ class WhatWillUseForControllerSpec extends UnitSpec with MockitoSugar with Befor
         result => {
           status(result) shouldBe SEE_OTHER
           redirectLocation(result) shouldBe Some(routes.TimeoutController.timeout().url)
+        }
+      )
+    }
+  }
+
+  "Sending a submission to the WhatWillUseForController when NOT enrolled" should {
+    "redirect to the Subscription Service" in {
+      submitWithSessionAndAuth(WhatWillUseForControllerTest.submit)(
+        result => {
+          status(result) shouldBe SEE_OTHER
+          redirectLocation(result) shouldBe Some(FrontendAppConfig.subscriptionUrl)
         }
       )
     }

--- a/test/views/AcknowledgementSpec.scala
+++ b/test/views/AcknowledgementSpec.scala
@@ -16,23 +16,23 @@
 
 package views
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import common.KeystoreKeys
 import config.FrontendAppConfig
-import connectors.{SubmissionConnector, KeystoreConnector}
-import controllers.{routes, AcknowledgementController}
-import controllers.helpers.{TestHelper, FakeRequestHelper}
-import models.{SubmissionRequest, SubmissionResponse, YourCompanyNeedModel, ContactDetailsModel}
+import connectors.{EnrolmentConnector, KeystoreConnector, SubmissionConnector}
+import controllers.{AcknowledgementController, routes}
+import controllers.helpers.{FakeRequestHelper, TestHelper}
+import models.{ContactDetailsModel, SubmissionRequest, SubmissionResponse, YourCompanyNeedModel}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.mockito.Matchers
 import org.mockito.Mockito._
 import org.specs2.mock.Mockito
 import play.api.i18n.Messages
-import play.api.libs.json.{Json, JsValue}
+import play.api.libs.json.{JsValue, Json}
 import uk.gov.hmrc.play.http.HttpResponse
 import uk.gov.hmrc.play.http.ws.WSHttp
-import uk.gov.hmrc.play.test.{WithFakeApplication, UnitSpec}
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 import play.api.test.Helpers._
 
 import scala.concurrent.Future
@@ -49,13 +49,17 @@ import scala.concurrent.Future
 
   class SetupPage {
 
-      val controller = new AcknowledgementController{
-        override lazy val applicationConfig = FrontendAppConfig
-        override lazy val authConnector = MockAuthConnector
-        val keyStoreConnector: KeystoreConnector = mockKeyStoreConnector
-        val submissionConnector: SubmissionConnector = mockSubmission
-      }
+    val controller = new AcknowledgementController {
+      override lazy val applicationConfig = FrontendAppConfig
+      override lazy val authConnector = MockAuthConnector
+      val keyStoreConnector: KeystoreConnector = mockKeyStoreConnector
+      val submissionConnector: SubmissionConnector = mockSubmission
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
+  }
 
     "The Acknowledgement page" should {
 

--- a/test/views/CheckAnswersCompanyDetailsSpec.scala
+++ b/test/views/CheckAnswersCompanyDetailsSpec.scala
@@ -34,10 +34,10 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import common.{Constants, KeystoreKeys}
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.{CheckAnswersController, routes}
 import controllers.helpers.FakeRequestHelper
 import models._
@@ -81,7 +81,11 @@ class CheckAnswersCompanyDetailsSpec extends UnitSpec with WithFakeApplication w
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   override def beforeEach() {

--- a/test/views/CheckAnswersContactDetailsSpec.scala
+++ b/test/views/CheckAnswersContactDetailsSpec.scala
@@ -34,10 +34,10 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import common.{Constants, KeystoreKeys}
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.{CheckAnswersController, routes}
 import controllers.helpers.FakeRequestHelper
 import models._
@@ -66,7 +66,11 @@ class CheckAnswersContactDetailsSpec extends UnitSpec with WithFakeApplication w
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   override def beforeEach() {

--- a/test/views/CheckAnswersInvestmentSpec.scala
+++ b/test/views/CheckAnswersInvestmentSpec.scala
@@ -34,10 +34,10 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import common.{Constants, KeystoreKeys}
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.{CheckAnswersController, routes}
 import controllers.helpers.FakeRequestHelper
 import models._
@@ -77,7 +77,11 @@ class CheckAnswersInvestmentSpec extends UnitSpec with WithFakeApplication with 
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   override def beforeEach() {

--- a/test/views/CheckAnswersPreviousSchemeSpec.scala
+++ b/test/views/CheckAnswersPreviousSchemeSpec.scala
@@ -34,10 +34,10 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import common.{Constants, KeystoreKeys}
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.{CheckAnswersController, routes}
 import controllers.helpers.FakeRequestHelper
 import models._
@@ -63,7 +63,11 @@ class CheckAnswersPreviousSchemeSpec extends UnitSpec with WithFakeApplication w
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+     when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+       .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   override def beforeEach() {

--- a/test/views/CheckAnswersSupportingDocsSpec.scala
+++ b/test/views/CheckAnswersSupportingDocsSpec.scala
@@ -34,10 +34,10 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import common.{Constants, KeystoreKeys}
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.{CheckAnswersController, routes}
 import controllers.helpers.FakeRequestHelper
 import models._
@@ -63,7 +63,11 @@ class CheckAnswersSupportingDocsSpec extends UnitSpec with WithFakeApplication w
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   override def beforeEach() {

--- a/test/views/CommercialSaleSpec.scala
+++ b/test/views/CommercialSaleSpec.scala
@@ -18,10 +18,10 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import common.Constants
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.{CommercialSaleController, routes}
 import controllers.helpers.FakeRequestHelper
 import models.CommercialSaleModel
@@ -51,7 +51,11 @@ class CommercialSaleSpec extends UnitSpec with WithFakeApplication with MockitoS
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   "The Contact Details page" should {

--- a/test/views/ConfirmCorrespondAddressSpec.scala
+++ b/test/views/ConfirmCorrespondAddressSpec.scala
@@ -18,10 +18,10 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import common.Constants
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.helpers.FakeRequestHelper
 import controllers.{ConfirmCorrespondAddressController, routes}
 import models.ConfirmCorrespondAddressModel
@@ -49,7 +49,11 @@ class ConfirmCorrespondAddressSpec extends UnitSpec with WithFakeApplication wit
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   "The Confirm Correspondence Address page" should {

--- a/test/views/ContactAddressSpec.scala
+++ b/test/views/ContactAddressSpec.scala
@@ -18,11 +18,11 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import builders.SessionBuilder
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
-import controllers.{routes, ContactAddressController}
+import connectors.{EnrolmentConnector, KeystoreConnector}
+import controllers.{ContactAddressController, routes}
 import controllers.helpers.FakeRequestHelper
 import models.ContactAddressModel
 import org.jsoup.Jsoup
@@ -48,7 +48,11 @@ class ContactAddressSpec extends UnitSpec with WithFakeApplication with MockitoS
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   "The Contact Address page" should {

--- a/test/views/ContactDetailsSpec.scala
+++ b/test/views/ContactDetailsSpec.scala
@@ -18,9 +18,9 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.helpers.FakeRequestHelper
 import controllers.{ContactDetailsController, routes}
 import models.ContactDetailsModel
@@ -48,7 +48,11 @@ class ContactDetailsSpec extends UnitSpec with WithFakeApplication with MockitoS
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   "The Contact Details page" should {

--- a/test/views/DateOfIncorporationSpec.scala
+++ b/test/views/DateOfIncorporationSpec.scala
@@ -18,9 +18,9 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.{DateOfIncorporationController, routes}
 import controllers.helpers.{FakeRequestHelper, TestHelper}
 import models.DateOfIncorporationModel
@@ -48,7 +48,11 @@ class DateOfIncorporationSpec extends UnitSpec with WithFakeApplication with Moc
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   "The Date Of Incorporation page" should {

--- a/test/views/HadPreviousRFISpec.scala
+++ b/test/views/HadPreviousRFISpec.scala
@@ -18,11 +18,11 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import builders.SessionBuilder
 import common.Constants
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.helpers.FakeRequestHelper
 import controllers.{HadPreviousRFIController, routes}
 import models.HadPreviousRFIModel
@@ -50,7 +50,11 @@ class HadPreviousRFISpec extends UnitSpec with WithFakeApplication with MockitoS
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   "Verify that the hadPreviousRFI page contains the correct elements " +

--- a/test/views/HowToApplySpec.scala
+++ b/test/views/HowToApplySpec.scala
@@ -18,9 +18,9 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.HowToApplyController
 import controllers.routes
 import controllers.helpers.FakeRequestHelper
@@ -46,7 +46,11 @@ class HowToApplySpec extends UnitSpec with WithFakeApplication with MockitoSugar
     val controller = new HowToApplyController{
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
 

--- a/test/views/IneligibleForKISpec.scala
+++ b/test/views/IneligibleForKISpec.scala
@@ -17,10 +17,11 @@
 package views
 
 import java.util.UUID
-import auth.MockAuthConnector
+
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import common.KeystoreKeys
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.{IneligibleForKIController, routes}
 import controllers.helpers.FakeRequestHelper
 import org.jsoup.Jsoup
@@ -44,7 +45,11 @@ class IneligibleForKISpec extends UnitSpec with WithFakeApplication with Mockito
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   "The Ineligible for Knowledge Intensive page" should {

--- a/test/views/InvestmentGrowSpec.scala
+++ b/test/views/InvestmentGrowSpec.scala
@@ -18,11 +18,11 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import builders.SessionBuilder
 import common.{Constants, KeystoreKeys}
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.{InvestmentGrowController, routes}
 import controllers.helpers.FakeRequestHelper
 import models._
@@ -50,7 +50,11 @@ class InvestmentGrowSpec extends UnitSpec with WithFakeApplication with MockitoS
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector : KeystoreConnector = mockKeyStoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   override def beforeEach() {

--- a/test/views/IsKnowledgeIntensiveSpec.scala
+++ b/test/views/IsKnowledgeIntensiveSpec.scala
@@ -18,11 +18,11 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import builders.SessionBuilder
 import common.Constants
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.helpers.FakeRequestHelper
 import controllers.{IsKnowledgeIntensiveController, routes}
 import models.IsKnowledgeIntensiveModel
@@ -50,7 +50,11 @@ class IsKnowledgeIntensiveSpec extends UnitSpec with WithFakeApplication with Mo
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   "Verify that the isKnowledgeIntensive page contains the correct elements " +

--- a/test/views/LifetimeAllowanceExceededSpec.scala
+++ b/test/views/LifetimeAllowanceExceededSpec.scala
@@ -18,17 +18,21 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.helpers.FakeRequestHelper
-import controllers.{LifetimeAllowanceExceededController, HowToApplyController, routes}
+import controllers.{HowToApplyController, LifetimeAllowanceExceededController, routes}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
+import org.mockito.Matchers
+import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import play.api.i18n.Messages
 import play.api.test.Helpers._
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+
+import scala.concurrent.Future
 
 class LifetimeAllowanceExceededSpec extends UnitSpec with WithFakeApplication with MockitoSugar with FakeRequestHelper{
 
@@ -40,7 +44,11 @@ class LifetimeAllowanceExceededSpec extends UnitSpec with WithFakeApplication wi
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
 

--- a/test/views/NatureOfBusinessSpec.scala
+++ b/test/views/NatureOfBusinessSpec.scala
@@ -18,10 +18,9 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
-
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.{NatureOfBusinessController, routes}
 import controllers.helpers.FakeRequestHelper
 import models.NatureOfBusinessModel
@@ -49,7 +48,11 @@ class NatureOfBusinessSpec extends UnitSpec with WithFakeApplication with Mockit
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   "The Nature of business page" should {

--- a/test/views/NewGeographicalMarketSpec.scala
+++ b/test/views/NewGeographicalMarketSpec.scala
@@ -18,11 +18,11 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import builders.SessionBuilder
 import common.{Constants, KeystoreKeys}
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.{NewGeographicalMarketController, routes}
 import controllers.helpers.FakeRequestHelper
 import models._
@@ -50,7 +50,11 @@ class NewGeographicalMarketSpec extends UnitSpec with WithFakeApplication with M
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector : KeystoreConnector = mockKeyStoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   override def beforeEach() {

--- a/test/views/NewProductSpec.scala
+++ b/test/views/NewProductSpec.scala
@@ -18,11 +18,11 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import builders.SessionBuilder
 import common.{Constants, KeystoreKeys}
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.helpers.FakeRequestHelper
 import controllers.{NewProductController, routes}
 import models.{NewProductModel, SubsidiariesModel}
@@ -54,7 +54,11 @@ class NewProductSpec extends UnitSpec with WithFakeApplication with MockitoSugar
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   "Verify that the NewProduct page contains the correct elements " +

--- a/test/views/OperatingCostsSpec.scala
+++ b/test/views/OperatingCostsSpec.scala
@@ -18,10 +18,10 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import builders.SessionBuilder
 import config.FrontendAppConfig
-import connectors.{KeystoreConnector, SubmissionConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector, SubmissionConnector}
 import controllers.helpers.FakeRequestHelper
 import controllers.{IsKnowledgeIntensiveController, OperatingCostsController, routes}
 import models.{IsKnowledgeIntensiveModel, OperatingCostsModel}
@@ -51,7 +51,10 @@ class OperatingCostsSpec extends UnitSpec with WithFakeApplication with MockitoS
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
       val submissionConnector: SubmissionConnector = mockSubmissionConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   "Verify that the OperatingCosts page contains the correct elements " +

--- a/test/views/PercentageStaffWithMastersSpec.scala
+++ b/test/views/PercentageStaffWithMastersSpec.scala
@@ -18,11 +18,11 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import builders.SessionBuilder
 import common.Constants
 import config.FrontendAppConfig
-import connectors.{KeystoreConnector, SubmissionConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector, SubmissionConnector}
 import controllers.helpers.FakeRequestHelper
 import controllers.{PercentageStaffWithMastersController, routes}
 import models.PercentageStaffWithMastersModel
@@ -52,7 +52,11 @@ class PercentageStaffWithMastersSpec extends UnitSpec with WithFakeApplication w
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
       val submissionConnector: SubmissionConnector = mockSubmissionConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   "Verify that the PercentageStaffWithMasters page contains the correct elements " +

--- a/test/views/PreviousBeforeDOFCSSpec.scala
+++ b/test/views/PreviousBeforeDOFCSSpec.scala
@@ -18,11 +18,11 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import builders.SessionBuilder
 import common.Constants
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.helpers.FakeRequestHelper
 import controllers.{PreviousBeforeDOFCSController, routes}
 import models.PreviousBeforeDOFCSModel
@@ -50,7 +50,11 @@ class PreviousBeforeDOFCSSpec extends UnitSpec with WithFakeApplication with Moc
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   "Verify that the previousBeforeDOFCS page contains the correct elements " +

--- a/test/views/PreviousSchemeSpec.scala
+++ b/test/views/PreviousSchemeSpec.scala
@@ -18,10 +18,10 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import common.{Constants, KeystoreKeys}
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.{PreviousSchemeController, routes}
 import controllers.helpers.{FakeRequestHelper, TestHelper}
 import models.PreviousSchemeModel
@@ -59,7 +59,11 @@ class PreviousSchemeSpec extends UnitSpec with WithFakeApplication with MockitoS
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   "The Previous Scheme page" should {

--- a/test/views/ProposedInvestmentSpec.scala
+++ b/test/views/ProposedInvestmentSpec.scala
@@ -18,10 +18,10 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import common.KeystoreKeys
 import config.FrontendAppConfig
-import connectors.{KeystoreConnector, SubmissionConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector, SubmissionConnector}
 import controllers.{ProposedInvestmentController, routes}
 import controllers.helpers.FakeRequestHelper
 import models.ProposedInvestmentModel
@@ -51,7 +51,11 @@ class ProposedInvestmentSpec extends UnitSpec with WithFakeApplication with Mock
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
       val submissionConnector: SubmissionConnector = mockSubmissionConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   "The Proposed Investment page" should {

--- a/test/views/QualifyingForSchemeSpec.scala
+++ b/test/views/QualifyingForSchemeSpec.scala
@@ -18,18 +18,22 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import builders.SessionBuilder
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.{QualifyingForSchemeController, routes}
 import controllers.helpers.{FakeRequestHelper, TestHelper}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
+import org.mockito.Matchers
+import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import play.api.i18n.Messages
 import play.api.test.Helpers._
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+
+import scala.concurrent.Future
 
 class QualifyingForSchemeSpec extends UnitSpec with WithFakeApplication with MockitoSugar with FakeRequestHelper{
 
@@ -38,7 +42,11 @@ class QualifyingForSchemeSpec extends UnitSpec with WithFakeApplication with Moc
     val controller = new QualifyingForSchemeController{
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   "The Qualifying for Scheme page" should {

--- a/test/views/RegisteredAddressSpec.scala
+++ b/test/views/RegisteredAddressSpec.scala
@@ -18,10 +18,10 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import builders.SessionBuilder
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.helpers.FakeRequestHelper
 import controllers.{RegisteredAddressController, routes}
 import models.RegisteredAddressModel
@@ -48,7 +48,11 @@ class RegisteredAddressSpec extends UnitSpec with WithFakeApplication with Mocki
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   "The Registered Address page" should {

--- a/test/views/ReviewPreviousSchemesSpec.scala
+++ b/test/views/ReviewPreviousSchemesSpec.scala
@@ -18,14 +18,14 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import builders.SessionBuilder
 import common.Constants
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.helpers.FakeRequestHelper
 import controllers.{ReviewPreviousSchemesController, routes}
-import models.{PreviousSchemeModel}
+import models.PreviousSchemeModel
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.mockito.Matchers
@@ -59,7 +59,11 @@ class ReviewPreviousSchemesSpec extends UnitSpec with WithFakeApplication with M
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   "The Review Previous Schemes Spec page" should {

--- a/test/views/SubsidiariesNinetyOwnedSpec.scala
+++ b/test/views/SubsidiariesNinetyOwnedSpec.scala
@@ -18,10 +18,10 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import common.Constants
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.{SubsidiariesNinetyOwnedController, TaxpayerReferenceController, routes}
 import controllers.helpers.FakeRequestHelper
 import models.{SubsidiariesNinetyOwnedModel, TaxpayerReferenceModel}
@@ -49,7 +49,11 @@ class SubsidiariesNinetyOwnedSpec extends UnitSpec with WithFakeApplication with
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   "The Subsidiaries Ninety Owned page" should {

--- a/test/views/SubsidiariesSpec.scala
+++ b/test/views/SubsidiariesSpec.scala
@@ -32,9 +32,9 @@
 
 package views
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.{SubsidiariesController, routes}
 import controllers.helpers.FakeRequestHelper
 import models.SubsidiariesModel
@@ -67,7 +67,11 @@ class SubsidiariesSpec extends UnitSpec with WithFakeApplication with MockitoSug
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   override def beforeEach() {

--- a/test/views/SubsidiariesSpendingInvestmentSpec.scala
+++ b/test/views/SubsidiariesSpendingInvestmentSpec.scala
@@ -18,14 +18,14 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import builders.SessionBuilder
 import common.{Constants, KeystoreKeys}
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.{SubsidiariesSpendingInvestmentController, routes}
 import controllers.helpers.FakeRequestHelper
-import models.{PreviousBeforeDOFCSModel, WhatWillUseForModel, NewProductModel, SubsidiariesSpendingInvestmentModel}
+import models.{NewProductModel, PreviousBeforeDOFCSModel, SubsidiariesSpendingInvestmentModel, WhatWillUseForModel}
 import org.jsoup.Jsoup
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.mock.MockitoSugar
@@ -50,7 +50,11 @@ class SubsidiariesSpendingInvestmentSpec extends UnitSpec with WithFakeApplicati
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector : KeystoreConnector = mockKeyStoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   override def beforeEach() {

--- a/test/views/SupportingDocumentsSpec.scala
+++ b/test/views/SupportingDocumentsSpec.scala
@@ -18,10 +18,10 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import common.KeystoreKeys
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.helpers.FakeRequestHelper
 import controllers.{SupportingDocumentsController, routes}
 import org.jsoup.Jsoup
@@ -44,7 +44,11 @@ class SupportingDocumentsSpec extends UnitSpec with WithFakeApplication with Moc
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   "The Supporting documents page" should {

--- a/test/views/TaxpayerReferenceSpec.scala
+++ b/test/views/TaxpayerReferenceSpec.scala
@@ -18,10 +18,9 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
-
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.{TaxpayerReferenceController, routes}
 import controllers.helpers.FakeRequestHelper
 import models.TaxpayerReferenceModel
@@ -49,7 +48,11 @@ class TaxpayerReferenceSpec extends UnitSpec with WithFakeApplication with Mocki
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   "The Contact Details page" should {

--- a/test/views/TenYearPlanSpec.scala
+++ b/test/views/TenYearPlanSpec.scala
@@ -18,10 +18,10 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import common.Constants
 import config.FrontendAppConfig
-import connectors.{KeystoreConnector, SubmissionConnector}
+import connectors.{EnrolmentConnector, KeystoreConnector, SubmissionConnector}
 import controllers.helpers.FakeRequestHelper
 import controllers.{CommercialSaleController, TenYearPlanController, routes}
 import models.{CommercialSaleModel, TenYearPlanModel}
@@ -53,7 +53,11 @@ class TenYearPlanSpec extends UnitSpec with WithFakeApplication with MockitoSuga
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
       val submissionConnector: SubmissionConnector = mockSubmissionConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   "The Ten Year Plan page" should {

--- a/test/views/UsedInvestmentReasonBeforeSpec.scala
+++ b/test/views/UsedInvestmentReasonBeforeSpec.scala
@@ -18,10 +18,10 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import builders.SessionBuilder
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.helpers.FakeRequestHelper
 import controllers.{UsedInvestmentReasonBeforeController, routes}
 import models.UsedInvestmentReasonBeforeModel
@@ -49,7 +49,11 @@ class UsedInvestmentReasonBeforeSpec extends UnitSpec with WithFakeApplication w
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   "Verify that the UsedInvestmentReasonBefore page contains the correct elements " +

--- a/test/views/WhatWeAskYouSpec.scala
+++ b/test/views/WhatWeAskYouSpec.scala
@@ -18,17 +18,22 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import config.FrontendAppConfig
+import connectors.EnrolmentConnector
 import controllers.WhatWeAskYouController
 import controllers.routes
-import controllers.helpers.{FakeRequestHelper}
+import controllers.helpers.FakeRequestHelper
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
+import org.mockito.Matchers
+import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import play.api.i18n.Messages
 import play.api.test.Helpers._
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+
+import scala.concurrent.Future
 
 class WhatWeAskYouSpec extends UnitSpec with WithFakeApplication with MockitoSugar with FakeRequestHelper{
 
@@ -37,7 +42,11 @@ class WhatWeAskYouSpec extends UnitSpec with WithFakeApplication with MockitoSug
     val controller = new WhatWeAskYouController{
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
 

--- a/test/views/WhatWillUseForSpec.scala
+++ b/test/views/WhatWillUseForSpec.scala
@@ -18,10 +18,10 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import builders.SessionBuilder
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.helpers.FakeRequestHelper
 import controllers.{IsKnowledgeIntensiveController, WhatWillUseForController, routes}
 import models.{IsKnowledgeIntensiveModel, WhatWillUseForModel}
@@ -49,7 +49,11 @@ class WhatWillUseForSpec extends UnitSpec with WithFakeApplication with MockitoS
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   "Verify that the WhatWillUseFor page contains the correct elements " +

--- a/test/views/YourCompanyNeedSpec.scala
+++ b/test/views/YourCompanyNeedSpec.scala
@@ -18,10 +18,10 @@ package views
 
 import java.util.UUID
 
-import auth.MockAuthConnector
+import auth.{Enrolment, Identifier, MockAuthConnector}
 import builders.SessionBuilder
 import config.FrontendAppConfig
-import connectors.KeystoreConnector
+import connectors.{EnrolmentConnector, KeystoreConnector}
 import controllers.helpers.FakeRequestHelper
 import controllers.{YourCompanyNeedController, routes}
 import models.YourCompanyNeedModel
@@ -32,7 +32,6 @@ import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import play.api.i18n.Messages
 import play.api.test.Helpers._
-
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 
 import scala.concurrent.Future
@@ -50,7 +49,11 @@ class YourCompanyNeedSpec extends UnitSpec with WithFakeApplication with Mockito
       override lazy val applicationConfig = FrontendAppConfig
       override lazy val authConnector = MockAuthConnector
       val keyStoreConnector: KeystoreConnector = mockKeystoreConnector
+      override lazy val enrolmentConnector = mock[EnrolmentConnector]
     }
+
+    when(controller.enrolmentConnector.getTAVCEnrolment(Matchers.any())(Matchers.any()))
+      .thenReturn(Future.successful(Option(Enrolment("HMRC-TAVC-ORG", Seq(Identifier("TavcReference", "1234")), "Activated"))))
   }
 
   "Verify that the yourCompanyNeed page contains the correct elements " +


### PR DESCRIPTION
I did consider creating the enrolment check as a `PageVisibilityPredicate` and then have a `CompositePageVisibilityPredicate` similar to PLA but thought this was overkill and it was easier to re-use as much of the existing functionality from the back-end without implementing a `PageVisibilityPredicate`.

This could be a potential future refactor but thought Keep It Simple for now.

- Added an `EnrolmentConnector` which connects to the enrolment end-point on Auth to retrieve the TAVC enrolment.
- Extended the Authorised predicate to include a check for the enrolment (refacotred to `AuthorisedAndEnrolledForTAVC` )
- Added Specific Tests for the Enrolment Connector as part of the `TAVCAuthEnrolledSpec`
- Added tests for all the controllers to check for enrolled and NOT enrolled results for both the GET and POST actions.
- Replaced the `Authorised.async` action with `AuthorisedAndEnrolled.async` action