### PR TITLE
TAVC-1572: Added the confirm contact details page

### DIFF
--- a/app/common/KeystoreKeys.scala
+++ b/app/common/KeystoreKeys.scala
@@ -42,7 +42,10 @@ trait KeystoreKeys {
   val investmentGrow: String = "investment:investmentGrow"
   val confirmContactAddress: String = "contactInformation:confirmCorrespondAddress"
   val checkYourAnswers: String = "checkAndSubmit:checkYourAnswers"
-  val contactDetails: String = "examples:contactDetails"
+  val manualContactAddress: String = "contactInformation:manualCorrespondAddress"
+  val manualContactDetails: String = "contactInformation:manualContactDetails"
+  val contactDetails: String = "contactInformation:contactDetails"
+  val confirmContactDetails: String = "contactInformation:confirmContactDetails"
   val contactAddress: String = "contactInformation:contactAddress"
   val previousSchemes: String = "previousInvestmentScheme:previousInvestmentSchemes"
 
@@ -59,5 +62,6 @@ trait KeystoreKeys {
   val backLinkPreviousScheme: String = "backLink:previousScheme"
   val backLinkProposedInvestment: String = "backLink:proposedInvestment"
   val backLinkIneligibleForKI: String = "backLink:IneligibleForKI"
+  val backLinkConfirmCorrespondence: String = "backLink:ConfirmCorrespondenceAddress"
 
 }

--- a/app/controllers/ConfirmContactDetailsController.scala
+++ b/app/controllers/ConfirmContactDetailsController.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import auth.AuthorisedAndEnrolledForTAVC
+import common.{Constants, KeystoreKeys}
+import config.{FrontendAppConfig, FrontendAuthConnector}
+import connectors.{EnrolmentConnector, S4LConnector}
+import forms.ConfirmContactDetailsForm._
+import models.{ConfirmContactDetailsModel, ContactDetailsModel}
+import uk.gov.hmrc.play.frontend.controller.FrontendController
+import views.html.contactInformation.ConfirmContactDetails
+
+import scala.concurrent.Future
+
+object ConfirmContactDetailsController extends ConfirmContactDetailsController{
+  val s4lConnector: S4LConnector = S4LConnector
+  override lazy val applicationConfig = FrontendAppConfig
+  override lazy val authConnector = FrontendAuthConnector
+  override lazy val enrolmentConnector = EnrolmentConnector
+}
+
+trait ConfirmContactDetailsController extends FrontendController with AuthorisedAndEnrolledForTAVC {
+
+  val s4lConnector: S4LConnector
+
+  val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
+
+    def getContactDetailModels = {
+      for {
+        confirmContactDetails <- s4lConnector.fetchAndGetFormData[ConfirmContactDetailsModel](KeystoreKeys.confirmContactDetails)
+      } yield confirmContactDetails
+    }
+
+    getContactDetailModels.map {
+      case Some(confirmContactDetails) =>
+        Ok(ConfirmContactDetails(confirmContactDetailsForm.fill(confirmContactDetails)))
+      case _ =>
+        Ok(ConfirmContactDetails(confirmContactDetailsForm.fill(ConfirmContactDetailsModel("", getContactDetails))))
+    }
+  }
+
+  //TODO: get the address below from ETMP when play this story
+  def getContactDetails: ContactDetailsModel = {
+    ContactDetailsModel("Forename", "Surname", Some("01234 567890"), Some("07777 123456"), "email@email.com")
+  }
+
+  val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
+    confirmContactDetailsForm.bindFromRequest().fold(
+      formWithErrors => {
+        Future.successful(BadRequest(ConfirmContactDetails(formWithErrors)))
+      },
+      validFormData => {
+        s4lConnector.saveFormData(KeystoreKeys.confirmContactDetails, validFormData)
+        validFormData.contactDetailsUse match {
+          case Constants.StandardRadioButtonYesValue => {
+            s4lConnector.saveFormData(KeystoreKeys.backLinkConfirmCorrespondence, routes.ConfirmContactDetailsController.show().url)
+            s4lConnector.saveFormData(KeystoreKeys.contactDetails, validFormData.contactDetails)
+            Future.successful(Redirect(routes.ConfirmCorrespondAddressController.show()))
+          }
+          case Constants.StandardRadioButtonNoValue => {
+            s4lConnector.saveFormData(KeystoreKeys.backLinkConfirmCorrespondence, routes.ContactDetailsController.show().url)
+            Future.successful(Redirect(routes.ContactDetailsController.show()))
+          }
+        }
+      }
+    )
+  }
+}

--- a/app/controllers/ContactAddressController.scala
+++ b/app/controllers/ContactAddressController.scala
@@ -45,7 +45,7 @@ trait ContactAddressController extends FrontendController with AuthorisedAndEnro
   lazy val countriesList = CountriesHelper.getIsoCodeTupleList
 
   val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
-    s4lConnector.fetchAndGetFormData[AddressModel](KeystoreKeys.contactAddress).map {
+    s4lConnector.fetchAndGetFormData[AddressModel](KeystoreKeys.manualContactAddress).map {
       case Some(data) => Ok(ContactAddress(contactAddressForm.fill(data), countriesList))
       case None => Ok(ContactAddress(contactAddressForm.fill(AddressModel("","")), countriesList))
     }
@@ -58,6 +58,7 @@ trait ContactAddressController extends FrontendController with AuthorisedAndEnro
           formWithErrors.discardingErrors.withError("postcode", Messages("validation.error.countrypostcode")) else formWithErrors, countriesList)))
       },
       validFormData => {
+        s4lConnector.saveFormData(KeystoreKeys.manualContactAddress, validFormData)
         s4lConnector.saveFormData(KeystoreKeys.contactAddress, validFormData)
         s4lConnector.saveFormData(KeystoreKeys.backLinkSupportingDocs, routes.ContactAddressController.show().toString())
         Future.successful(Redirect(routes.SupportingDocumentsController.show()))

--- a/app/controllers/ContactDetailsController.scala
+++ b/app/controllers/ContactDetailsController.scala
@@ -40,7 +40,7 @@ trait ContactDetailsController extends FrontendController with AuthorisedAndEnro
   val s4lConnector: S4LConnector
 
   val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
-    s4lConnector.fetchAndGetFormData[ContactDetailsModel](KeystoreKeys.contactDetails).map {
+    s4lConnector.fetchAndGetFormData[ContactDetailsModel](KeystoreKeys.manualContactDetails).map {
       case Some(data) => Ok(ContactDetails(contactDetailsForm.fill(data)))
       case None => Ok(ContactDetails(contactDetailsForm))
     }
@@ -52,6 +52,7 @@ trait ContactDetailsController extends FrontendController with AuthorisedAndEnro
         Future.successful(BadRequest(ContactDetails(formWithErrors)))
       },
       validFormData => {
+        s4lConnector.saveFormData(KeystoreKeys.manualContactDetails, validFormData)
         s4lConnector.saveFormData(KeystoreKeys.contactDetails, validFormData)
         Future.successful(Redirect(routes.ConfirmCorrespondAddressController.show()))
       }

--- a/app/controllers/InvestmentGrowController.scala
+++ b/app/controllers/InvestmentGrowController.scala
@@ -69,7 +69,7 @@ trait InvestmentGrowController extends FrontendController with AuthorisedAndEnro
         },
       validForm => {
         s4lConnector.saveFormData(KeystoreKeys.investmentGrow, validForm)
-        Future.successful(Redirect(routes.ContactDetailsController.show()))
+        Future.successful(Redirect(routes.ConfirmContactDetailsController.show()))
       }
     )
   }

--- a/app/forms/ConfirmContactDetailsForm.scala
+++ b/app/forms/ConfirmContactDetailsForm.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import models.{ContactDetailsModel, ConfirmContactDetailsModel}
+import play.api.data.Form
+import play.api.data.Forms._
+
+object ConfirmContactDetailsForm {
+  val confirmContactDetailsForm = Form(
+    mapping(
+      "contactDetailsUse" -> nonEmptyText,
+      "contactDetails" -> mapping(
+        "forename" -> nonEmptyText,
+        "surname" -> nonEmptyText,
+        "telephoneNumber" -> optional(utils.Validation.telephoneNumberCheck),
+        "mobileNumber" -> optional(utils.Validation.telephoneNumberCheck),
+        "email" -> utils.Validation.emailCheck
+      )(ContactDetailsModel.apply)(ContactDetailsModel.unapply)
+    )(ConfirmContactDetailsModel.apply)(ConfirmContactDetailsModel.unapply)
+  )
+}

--- a/app/models/ConfirmContactDetailsModel.scala
+++ b/app/models/ConfirmContactDetailsModel.scala
@@ -18,18 +18,10 @@ package models
 
 import play.api.libs.json.Json
 
-case class ContactDetailsModel
-(
-  forename : String,
-  surname : String,
-  telephoneNumber: Option[String],
-  mobileNumber: Option[String],
-  email : String
-){
-  val fullName =  s"$forename $surname"
-}
+case class ConfirmContactDetailsModel (contactDetailsUse: String,
+                                       contactDetails:ContactDetailsModel)
 
-object ContactDetailsModel {
-  implicit val format = Json.format[ContactDetailsModel]
-  implicit val writes = Json.writes[ContactDetailsModel]
+object ConfirmContactDetailsModel {
+  implicit val format = Json.format[ConfirmContactDetailsModel]
+  implicit val writes = Json.writes[ConfirmContactDetailsModel]
 }

--- a/app/views/contactInformation/ConfirmContactDetails.scala.html
+++ b/app/views/contactInformation/ConfirmContactDetails.scala.html
@@ -1,0 +1,78 @@
+@import models.ConfirmCorrespondAddressModel
+@import common.Constants
+@import utils.CountriesHelper
+@import uk.gov.hmrc.play.views.html.helpers.form
+@import views.html.helpers.{errorSummary, formInputRadioGroup, textWithConstErrors, backButtonWithProgress, hiddenField}
+
+@(confirmContactDetailsForm: Form[ConfirmContactDetailsModel])(implicit request: Request[_])
+
+@main_template(Messages("page.contactInformation.ConfirmContactDetails.title")){
+
+    @backButtonWithProgress(controllers.routes.InvestmentGrowController.show().toString, Messages("common.section.progress.company.details.four"))
+
+    <div class="grid-row">
+        <div class="column-two-thirds">
+
+            @errorSummary(confirmContactDetailsForm, "confirm-contact-details", "contactDetailsUsed")
+
+            <h1 id="main-heading" class="form-title heading-xlarge">@Messages("page.contactInformation.ConfirmContactDetails.heading")</h1>
+
+            <div id="storedContactDetailsDiv" class="form-group">
+
+                <span id="name" class="h4-heading form-group">@confirmContactDetailsForm("contactDetails.forename").value @confirmContactDetailsForm("contactDetails.surname").value</span>
+                <span id="telephoneNumber" class="form-group">@confirmContactDetailsForm("contactDetails.telephoneNumber").value</span>
+                @if(confirmContactDetailsForm("contactDetails.mobileNumber").value.isDefined){
+                    <span id="mobileNumber" class="form-group">@confirmContactDetailsForm("contactDetails.mobileNumber").value</span>
+                }
+                <span id="email" class="form-group">@confirmContactDetailsForm("contactDetails.email").value</span>
+            </div>
+
+            @form(action = controllers.routes.ConfirmContactDetailsController.submit()) {
+                <div id="radioContactDetailsDiv">
+                    <div class="form-group">
+                        @formInputRadioGroup(
+                        field = confirmContactDetailsForm("contactDetailsUse"),
+                        Seq(
+                        Constants.StandardRadioButtonYesValue->Messages("common.radioYesLabel"),
+                        Constants.StandardRadioButtonNoValue->Messages("common.radioNoLabel")),
+                            '_legend -> Messages("page.contactInformation.confirmContactDetails.title"),
+                            '_legendClass -> "visuallyhidden",
+                            '_labelAfter -> true,
+                            '_labelClass -> "block-label",
+                            '_groupClass -> "inline"
+                        )
+                    </div>
+                </div>
+
+                <div>
+                    @hiddenField(
+                    confirmContactDetailsForm("contactDetails.forename"),
+                    'id -> "contactDetails.forename"
+                    )
+                    @hiddenField(
+                    confirmContactDetailsForm("contactDetails.surname"),
+                    'id -> "contactDetails.surname"
+                    )
+                    @hiddenField(
+                    confirmContactDetailsForm("contactDetails.telephoneNumber"),
+                    'id -> "contactDetails.telephoneNumber"
+                    )
+                    @hiddenField(
+                    confirmContactDetailsForm("contactDetails.mobileNumber"),
+                    'id -> "contactDetails.mobileNumber"
+                    )
+                    @hiddenField(
+                    confirmContactDetailsForm("contactDetails.email"),
+                    'id -> "contactDetails.email"
+                    )
+                </div>
+
+                <div class="form-group" id="contactDetailsButtonDiv">
+                    <button class="btn button" id="next" type="submit">@Messages("common.button.continue")</button>
+                </div>
+            }
+
+        </div>
+    </div>
+
+}

--- a/app/views/contactInformation/ConfirmCorrespondAddress.scala.html
+++ b/app/views/contactInformation/ConfirmCorrespondAddress.scala.html
@@ -4,11 +4,11 @@
 @import uk.gov.hmrc.play.views.html.helpers.form
 @import views.html.helpers.{errorSummary, formInputRadioGroup, textWithConstErrors, backButtonWithProgress, hiddenField}
 
-@(confirmCorrespondAddressForm: Form[ConfirmCorrespondAddressModel])(implicit request: Request[_])
+@(confirmCorrespondAddressForm: Form[ConfirmCorrespondAddressModel], backLink: String)(implicit request: Request[_])
 
 @main_template(Messages("page.contactInformation.ConfirmCorrespondAddress.title")){
 
-    @backButtonWithProgress(controllers.routes.ContactDetailsController.show().toString, Messages("common.section.progress.company.details.four"))
+    @backButtonWithProgress(backLink, Messages("common.section.progress.company.details.four"))
 
     <div class="grid-row">
         <div class="column-two-thirds">

--- a/app/views/contactInformation/ContactDetails.scala.html
+++ b/app/views/contactInformation/ContactDetails.scala.html
@@ -6,7 +6,7 @@
 
 @main_template(Messages("page.contactInformation.contactDetails.title")) {
 
-@backButtonWithProgress(controllers.routes.InvestmentGrowController.show().toString, Messages("common.section.progress.company.details.four"))
+@backButtonWithProgress(controllers.routes.ConfirmContactDetailsController.show().url, Messages("common.section.progress.company.details.four"))
 
 <div class="grid-row">
     <div class="column-two-thirds">

--- a/app/views/previousInvestment/PreviousScheme.scala.html
+++ b/app/views/previousInvestment/PreviousScheme.scala.html
@@ -33,7 +33,7 @@
             )
             </div>
 
-            <div class="panel-indent form-group"  id="hidden-other-scheme">
+            <div class="panel-indent form-group"  id="hidden-other-scheme"  data-hidden='hidden'>
                 @input(
                 previousSchemeForm("otherSchemeName"),
                 '_divClass -> "form-label",

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -101,6 +101,9 @@ POST       /supporting-documents                    controllers.SupportingDocume
 GET        /confirm-correspondence-address          controllers.ConfirmCorrespondAddressController.show
 POST       /confirm-correspondence-address          controllers.ConfirmCorrespondAddressController.submit
 
+GET        /confirm-contact-details                 controllers.ConfirmContactDetailsController.show
+POST       /confirm-contact-details                 controllers.ConfirmContactDetailsController.submit
+
 GET        /check-your-answers                      controllers.CheckAnswersController.show
 POST       /check-your-answers                      controllers.CheckAnswersController.submit
 

--- a/conf/messages
+++ b/conf/messages
@@ -478,6 +478,10 @@ page.contactInformation.contactDetails.phoneNumber.label=Landline (optional)
 page.contactInformation.contactDetails.mobileNumber.label=Mobile (optional)
 page.contactInformation.contactDetails.email.label=Email address
 
+#Confirm Contact Details Page
+page.contactInformation.ConfirmContactDetails.heading=Are these the contact details you want us to use for this application?
+page.contactInformation.ConfirmContactDetails.title=Are these the contact details you want us to use for this application?
+
 #summary questions section five
 page.summaryQuestion.supportingDocsSection=Section 5: Supporting documents
 page.summaryQuestion.supportingDocsSectionSubText=Remember to include your:

--- a/public/javascripts/itr.js
+++ b/public/javascripts/itr.js
@@ -108,7 +108,7 @@ $(document).ready($(function() {
 
         $checkbox.change(function() {
 
-//            ClearRevealingContentInputs();
+            ClearRevealingContentInputs();
             if ($checkbox.val() === 'Other') {
                  //alert($checkbox.val());
                 $hiddenOtherScheme.show();

--- a/public/javascripts/itr.js
+++ b/public/javascripts/itr.js
@@ -95,9 +95,20 @@ $(document).ready($(function() {
         var $hiddenOtherScheme = $('#hidden-other-scheme')
         var $hiddenInvestmentSpent = $('#hidden-investment-spent')
 
+        $hiddenInvestmentSpent.hide();
+        $hiddenOtherScheme.hide();
+
+        if ($checkbox.val() === 'Other' && $checkbox.prop('checked')) {
+            $hiddenOtherScheme.show();
+        }
+
+        if ($checkbox.val() === 'SEIS' && $checkbox.prop('checked')) {
+            $hiddenInvestmentSpent.show();
+        }
+
         $checkbox.change(function() {
 
-            ClearRevealingContentInputs();
+//            ClearRevealingContentInputs();
             if ($checkbox.val() === 'Other') {
                  //alert($checkbox.val());
                 $hiddenOtherScheme.show();

--- a/test/controllers/ConfirmContactDetailsControllerSpec.scala
+++ b/test/controllers/ConfirmContactDetailsControllerSpec.scala
@@ -23,16 +23,16 @@ import common.{Constants, KeystoreKeys}
 import config.{FrontendAppConfig, FrontendAuthConnector}
 import connectors.{EnrolmentConnector, S4LConnector}
 import controllers.helpers.ControllerSpec
-import models.{AddressModel, ConfirmCorrespondAddressModel}
+import models.ConfirmContactDetailsModel
 import org.mockito.Matchers
 import org.mockito.Mockito._
 import play.api.test.Helpers._
 
 import scala.concurrent.Future
 
-class ConfirmCorrespondAddressControllerSpec extends ControllerSpec {
+class ConfirmContactDetailsControllerSpec extends ControllerSpec {
 
-  object TestController extends ConfirmCorrespondAddressController {
+  object TestController extends ConfirmContactDetailsController {
     override lazy val applicationConfig = FrontendAppConfig
     override lazy val authConnector = MockAuthConnector
     override lazy val s4lConnector = mockS4lConnector
@@ -41,30 +41,27 @@ class ConfirmCorrespondAddressControllerSpec extends ControllerSpec {
 
   def setupMocks
   (
-    confirmCorrespondAddressModel: Option[ConfirmCorrespondAddressModel] = None,
-    backLink: Option[String] = None
+    confirmContactDetailsModel: Option[ConfirmContactDetailsModel] = None
   ): Unit = {
-    when(TestController.s4lConnector.fetchAndGetFormData[ConfirmCorrespondAddressModel](Matchers.eq(KeystoreKeys.confirmContactAddress))
-      (Matchers.any(), Matchers.any(), Matchers.any())).thenReturn(Future.successful(confirmCorrespondAddressModel))
-    when(TestController.s4lConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkConfirmCorrespondence))
-      (Matchers.any(), Matchers.any(),Matchers.any())).thenReturn(Future.successful(backLink))
+    when(TestController.s4lConnector.fetchAndGetFormData[ConfirmContactDetailsModel](Matchers.eq(KeystoreKeys.confirmContactDetails))
+      (Matchers.any(), Matchers.any(), Matchers.any())).thenReturn(Future.successful(confirmContactDetailsModel))
   }
 
-  "ConfirmCorrespondAddressController" should {
+  "ConfirmContactDetailsController" should {
     "use the correct auth connector" in {
-      ConfirmCorrespondAddressController.authConnector shouldBe FrontendAuthConnector
+      ConfirmContactDetailsController.authConnector shouldBe FrontendAuthConnector
     }
     "use the correct keystore connector" in {
-      ConfirmCorrespondAddressController.s4lConnector shouldBe S4LConnector
+      ConfirmContactDetailsController.s4lConnector shouldBe S4LConnector
     }
     "use the correct enrolment connector" in {
-      ConfirmCorrespondAddressController.enrolmentConnector shouldBe EnrolmentConnector
+      ConfirmContactDetailsController.enrolmentConnector shouldBe EnrolmentConnector
     }
   }
 
-  "Sending an Authenticated and Enrolled GET request with a session to ConfirmCorrespondAddressController" should {
+  "Sending an Authenticated and Enrolled GET request with a session to ConfirmContactDetailsController" should {
     "return a 200 when something is fetched from keystore" in {
-      setupMocks(Some(confirmCorrespondAddressModel),Some("backLink"))
+      setupMocks(Some(confirmContactDetailsModel))
       mockEnrolledRequest()
       showWithSessionAndAuth(TestController.show())(
         result => status(result) shouldBe OK
@@ -72,10 +69,10 @@ class ConfirmCorrespondAddressControllerSpec extends ControllerSpec {
     }
   }
 
-  //TODO: mock the addressModel returned form ETMP when implemented (currently is hard coded return in controller)
-  "Sending an Authenticated and Enrolled GET request with a session to ConfirmCorrespondAddressController" should {
-    "return a 200 when no contact address exists but an address is returned from ETMP" in {
-      setupMocks(None,Some("backLink"))
+  "Sending an Authenticated and Enrolled GET request with a session to ConfirmContactDetailsController" +
+    "where there is no data already stored" should {
+    "return a 200 when nothing is retrieved from Keystore" in {
+      setupMocks()
       mockEnrolledRequest()
       showWithSessionAndAuth(TestController.show())(
         result => status(result) shouldBe OK
@@ -83,23 +80,22 @@ class ConfirmCorrespondAddressControllerSpec extends ControllerSpec {
     }
   }
 
-
-  //TODO: Re-introduce when we try to get the addressModel form ETMP when it is then possible to mock a return none for this
+  //TODO: Re-introduce when we try to get the contactDetails from ETMP when it is then possible to mock a return none for this
 //    "provide an empty model and return a 200 when nothing is fetched using keystore" in {
 //      when(mockKeyStoreConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(cacheMap)
-//      when(mockKeyStoreConnector.fetchAndGetFormData[ConfirmCorrespondAddressModel](Matchers.any())(Matchers.any(), Matchers.any()))
+//      when(mockKeyStoreConnector.fetchAndGetFormData[ConfirmContactDetailsModel](Matchers.any())(Matchers.any(), Matchers.any()))
 //        .thenReturn(Future.successful(None))
 //      mockEnrolledRequest
-//      showWithSessionAndAuth(ConfirmCorrespondAddressControllerTest.show())(
+//      showWithSessionAndAuth(ConfirmContactDetailsControllerTest.show())(
 //        result => status(result) shouldBe OK
 //      )
 //    }
 //  }
 
-  "Sending an Authenticated and NOT Enrolled GET request with a session to ConfirmCorrespondAddressController" should {
+  "Sending an Authenticated and NOT Enrolled GET request with a session to ConfirmContactDetailsController" should {
 
     "return a 303 to the subscription url" in {
-      setupMocks(Some(confirmCorrespondAddressModel),Some("backLink"))
+      setupMocks(Some(confirmContactDetailsModel))
       mockNotEnrolledRequest()
       showWithSessionAndAuth(TestController.show())(
         result => {
@@ -110,7 +106,7 @@ class ConfirmCorrespondAddressControllerSpec extends ControllerSpec {
     }
   }
 
-  "Sending an Unauthenticated request with a session to ConfirmCorrespondAddressController" should {
+  "Sending an Unauthenticated request with a session to ConfirmContactDetailsController" should {
     "return a 302 and redirect to the GG login page" in {
       showWithSessionWithoutAuth(TestController.show())(
         result => {
@@ -123,7 +119,7 @@ class ConfirmCorrespondAddressControllerSpec extends ControllerSpec {
     }
   }
 
-  "Sending a request with no session to ConfirmCorrespondAddressController" should {
+  "Sending a request with no session to ConfirmContactDetailsController" should {
     "return a 302 and redirect to GG login" in {
       showWithoutSession(TestController.show())(
         result => {
@@ -136,7 +132,7 @@ class ConfirmCorrespondAddressControllerSpec extends ControllerSpec {
     }
   }
 
-  "Sending a timed-out request to ConfirmCorrespondAddressController" should {
+  "Sending a timed-out request to ConfirmContactDetailsController" should {
     "return a 302 and redirect to the timeout page" in {
       showWithTimeout(TestController.show())(
         result => {
@@ -148,61 +144,56 @@ class ConfirmCorrespondAddressControllerSpec extends ControllerSpec {
   }
 
 
-  "Submitting a valid form submission to ConfirmCorrespondAddressController while authenticated and enrolled" should {
-    "redirect Supporting Documents when the Yes option is selected" in {
-      setupMocks(Some(confirmCorrespondAddressModel),Some("backLink"))
+  "Submitting a valid form submission to ConfirmContactDetailsController while authenticated and enrolled" should {
+    "redirect Confirm Correspondence Address Page when the Yes option is selected" in {
+      setupMocks(Some(confirmContactDetailsModel))
       mockEnrolledRequest()
       val formInput = Seq(
-        "contactAddressUse" -> Constants.StandardRadioButtonYesValue,
-        "address.addressline1" -> "Line 1",
-        "address.addressline2" -> "Line 2",
-        "address.addressline3" -> "Line 3",
-        "address.addressline4" -> "line 4",
-        "address.postcode" -> "TF1 3NY",
-        "address.countryCode" -> "GB")
-
+        "contactDetailsUse" -> Constants.StandardRadioButtonYesValue,
+        "contactDetails.forename" -> "Hank",
+        "contactDetails.surname" -> "The Tank",
+        "contactDetails.telephoneNumber" -> "01234 567890",
+        "contactDetails.mobileNumber" -> "01234 567890",
+        "contactDetails.email" -> "thisiavalidemail@valid.com")
       submitWithSessionAndAuth(TestController.submit, formInput: _*)(
         result => {
           status(result) shouldBe SEE_OTHER
-          redirectLocation(result) shouldBe Some("/investment-tax-relief/supporting-documents")
+          redirectLocation(result) shouldBe Some(routes.ConfirmCorrespondAddressController.show().url)
         }
       )
     }
   }
-    "Submitting a valid form submission to ConfirmCorrespondAddressController while authenticated and enrolled" should {
+    "Submitting a valid form submission to ConfirmContactDetailsController while authenticated and enrolled" should {
     "redirect to Contact Address page when the 'No' option is selected" in {
-      setupMocks(Some(confirmCorrespondAddressModel),Some("backLink"))
+      setupMocks(Some(confirmContactDetailsModel))
       mockEnrolledRequest()
       val formInput = Seq(
-        "contactAddressUse" -> Constants.StandardRadioButtonNoValue,
-        "address.addressline1" -> "Line 1",
-        "address.addressline2" -> "Line 2",
-        "address.addressline3" -> "Line 3",
-        "address.addressline4" -> "line 4",
-        "address.postcode" -> "TF1 3NY",
-        "address.countryCode" -> "GB")
-
+        "contactDetailsUse" -> Constants.StandardRadioButtonNoValue,
+        "contactDetails.forename" -> "Hank",
+        "contactDetails.surname" -> "The Tank",
+        "contactDetails.telephoneNumber" -> "01234 567890",
+        "contactDetails.mobileNumber" -> "01234 567890",
+        "contactDetails.email" -> "thisiavalidemail@valid.com")
       submitWithSessionAndAuth(TestController.submit, formInput:_*)(
         result => {
           status(result) shouldBe SEE_OTHER
-          redirectLocation(result) shouldBe Some("/investment-tax-relief/contact-address")
+          redirectLocation(result) shouldBe Some(routes.ContactDetailsController.show().url)
         }
       )
     }
   }
 
-  "Submitting a invalid form submission to ConfirmCorrespondAddressController while authenticated and enrolled" should {
+  "Submitting a invalid form submission to ConfirmContactDetailsController while authenticated and enrolled" should {
     "redirect to itself when there is validation errors" in {
-      setupMocks(Some(confirmCorrespondAddressModel),Some("backLink"))
+      setupMocks(Some(confirmContactDetailsModel))
       mockEnrolledRequest()
       val formInput = Seq(
-        "contactAddressUse" -> "",
-        "address.addressline1" -> "Line 1",
-        "address.addressline2" -> "Line 2",
-        "address.addressline3" -> "Line 3",
-        "address.addressline4" -> "line 4",
-        "address.postcode" -> "TF1 3NY",
-        "address.countryCode" -> "GB")
+        "contactDetailsUse" -> "",
+        "contactDetails.forename" -> "Hank",
+        "contactDetails.surname" -> "The Tank",
+        "contactDetails.telephoneNumber" -> "01234 567890",
+        "contactDetails.mobileNumber" -> "01234 567890",
+        "contactDetails.email" -> "thisiavalidemail@valid.com")
        submitWithSessionAndAuth(TestController.submit, formInput:_*)(
           result => {
             status(result) shouldBe BAD_REQUEST
@@ -211,11 +202,11 @@ class ConfirmCorrespondAddressControllerSpec extends ControllerSpec {
       }
     }
 
-  "Submitting a form to ConfirmCorrespondAddressController with a session but not authenticated" should {
+  "Submitting a form to ConfirmContactDetailsController with a session but not authenticated" should {
 
     val formInput = "contactAddressUse" -> Constants.StandardRadioButtonYesValue
     "return a 303 and redirect to the GG login page" in {
-      setupMocks(Some(confirmCorrespondAddressModel),Some("backLink"))
+      setupMocks(Some(confirmContactDetailsModel))
       submitWithSessionWithoutAuth(TestController.submit, formInput)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -227,11 +218,11 @@ class ConfirmCorrespondAddressControllerSpec extends ControllerSpec {
     }
   }
 
-  "Submitting a form to ConfirmCorrespondAddressController with no session" should {
+  "Submitting a form to ConfirmContactDetailsController with no session" should {
 
     val formInput = "contactAddressUse" -> Constants.StandardRadioButtonYesValue
     "return a 303 and redirect to the GG login page" in {
-      setupMocks(Some(confirmCorrespondAddressModel),Some("backLink"))
+      setupMocks(Some(confirmContactDetailsModel))
       submitWithoutSession(TestController.submit, formInput)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -243,11 +234,11 @@ class ConfirmCorrespondAddressControllerSpec extends ControllerSpec {
     }
   }
 
-  "Submitting a form to ConfirmCorrespondAddressController with a timeout" should {
+  "Submitting a form to ConfirmContactDetailsController with a timeout" should {
 
     val formInput = "contactAddressUse" -> Constants.StandardRadioButtonYesValue
     "return a 303 and redirect to the timeout page" in {
-      setupMocks(Some(confirmCorrespondAddressModel),Some("backLink"))
+      setupMocks(Some(confirmContactDetailsModel))
       submitWithTimeout(TestController.submit, formInput)(
         result => {
           status(result) shouldBe SEE_OTHER
@@ -257,9 +248,9 @@ class ConfirmCorrespondAddressControllerSpec extends ControllerSpec {
     }
   }
 
-  "Submitting a form to ConfirmCorrespondAddressController when NOT enrolled" should {
+  "Submitting a form to ConfirmContactDetailsController when NOT enrolled" should {
     "return a 303 and redirect to the Subscription Service" in {
-      setupMocks(Some(confirmCorrespondAddressModel),Some("backLink"))
+      setupMocks(Some(confirmContactDetailsModel))
       mockNotEnrolledRequest()
       val formInput = "contactAddressUse" -> Constants.StandardRadioButtonYesValue
       submitWithSessionAndAuth(TestController.submit, formInput)(

--- a/test/controllers/InvestmentGrowControllerSpec.scala
+++ b/test/controllers/InvestmentGrowControllerSpec.scala
@@ -232,7 +232,7 @@ class InvestmentGrowControllerSpec extends ControllerSpec {
       submitWithSessionAndAuth(TestController.submit,formInput)(
         result => {
           status(result) shouldBe SEE_OTHER
-          redirectLocation(result) shouldBe Some("/investment-tax-relief/contact-details")
+          redirectLocation(result) shouldBe Some(routes.ConfirmContactDetailsController.show().url)
         }
       )
     }

--- a/test/controllers/helpers/BaseSpec.scala
+++ b/test/controllers/helpers/BaseSpec.scala
@@ -38,6 +38,7 @@ trait BaseSpec extends UnitSpec with WithFakeApplication with MockitoSugar with 
   }
 
   val contactDetailsModel = ContactDetailsModel("Test", "Name", Some("01111 111111"), None, "test@test.com")
+  val confirmContactDetailsModel = ConfirmContactDetailsModel(Constants.StandardRadioButtonYesValue, contactDetailsModel)
 
   val investmentGrowModel = InvestmentGrowModel("At vero eos et accusamusi et iusto odio dignissimos ducimus qui blanditiis praesentium " +
     "voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique " +

--- a/test/views/ConfirmContactDetailsSpec.scala
+++ b/test/views/ConfirmContactDetailsSpec.scala
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import models.{ConfirmContactDetailsModel, ContactDetailsModel}
+import org.jsoup.Jsoup
+import play.api.i18n.Messages
+import views.helpers.ViewSpec
+import forms.ConfirmContactDetailsForm._
+import views.html.contactInformation._
+import controllers.routes
+import uk.gov.hmrc.play.test.WithFakeApplication
+
+class ConfirmContactDetailsSpec extends ViewSpec with WithFakeApplication{
+
+  val contactDetailsNoMobile =  ContactDetailsModel("Barry","Barryson",Some("01234 555666"), None, "barry@barryson-ltd.com")
+  val contactDetailsMobile =  ContactDetailsModel("Barry","Barryson",Some("01234 555666"), Some("07777 123456"), "barry@barryson-ltd.com")
+
+  lazy val view = ConfirmContactDetails(confirmContactDetailsForm.fill(ConfirmContactDetailsModel("",contactDetailsNoMobile)))(fakeRequest)
+  lazy val viewWithMobile = ConfirmContactDetails(confirmContactDetailsForm.fill(ConfirmContactDetailsModel("",contactDetailsMobile)))(fakeRequest)
+  lazy val document = Jsoup.parse(view.body)
+  lazy val documentWithMobile = Jsoup.parse(viewWithMobile.body)
+
+  "The Confirm Contact Details page" should {
+
+    s"have the title '${Messages("page.contactInformation.ConfirmContactDetails.title")}" in {
+      document.title() shouldBe Messages("page.contactInformation.ConfirmContactDetails.title")
+    }
+
+    s"have the heading '${Messages("page.contactInformation.ConfirmContactDetails.heading")}" in {
+      document.getElementById("main-heading").text() shouldBe Messages("page.contactInformation.ConfirmContactDetails.heading")
+    }
+
+    "have a back-link" which {
+      s"has the text '${Messages("common.section.progress.company.details.four")}" in {
+        document.body.getElementById("back-link").text shouldEqual Messages("common.button.back")
+      }
+
+      s"has a link to '${routes.ContactDetailsController.show().url}" in {
+        document.body.getElementById("back-link").attr("href") shouldEqual routes.InvestmentGrowController.show().url
+      }
+
+      s"has a Section heading next to it of '${Messages("common.section.progress.company.details.four")}" in {
+        document.body.getElementById("progress-section").text shouldBe Messages("common.section.progress.company.details.four")
+      }
+    }
+
+    "have a continue button" in {
+      document.getElementById("next").text() shouldBe Messages("common.button.continue")
+    }
+
+    "have radio options" which {
+
+      "include a 'Yes' option" in {
+        document.body.getElementById("contactDetailsUse-yes").attr("value") shouldBe Messages("common.radioYesLabel")
+      }
+
+      "includes a 'No' option" in {
+        document.body.getElementById("contactDetailsUse-no").attr("value") shouldBe Messages("common.radioNoLabel")
+      }
+
+    }
+
+    "for a user with NO mobile should have a section for the contact details" which {
+
+      s"includes the name '${contactDetailsNoMobile.fullName}'" in {
+        document.body.getElementById("name").text shouldBe contactDetailsNoMobile.fullName
+      }
+
+      s"includes the Landline number '${contactDetailsNoMobile.telephoneNumber}'" in {
+        document.body.getElementById("telephoneNumber").text shouldBe contactDetailsNoMobile.telephoneNumber.get
+      }
+
+      s"does NOT include the mobile number" in {
+        document.body.getElementById("storedContactDetailsDiv").children().html() shouldNot contain ("mobileNumber")
+      }
+
+      s"includes the email address '${contactDetailsNoMobile.email}'" in {
+        document.body.getElementById("email").text shouldBe contactDetailsNoMobile.email
+      }
+
+    }
+
+    "for a user with mobile contact details should have a section for the contact details" which {
+
+      s"includes the name '${contactDetailsNoMobile.fullName}'" in {
+        documentWithMobile.body.getElementById("name").text shouldBe contactDetailsNoMobile.fullName
+      }
+
+      s"includes the Landline number '${contactDetailsNoMobile.telephoneNumber}'" in {
+        documentWithMobile.body.getElementById("telephoneNumber").text shouldBe contactDetailsNoMobile.telephoneNumber.get
+      }
+
+      s"includes the mobile number '${contactDetailsMobile.mobileNumber.get}'" in {
+        documentWithMobile.body.getElementById("mobileNumber").text shouldBe contactDetailsMobile.mobileNumber.get
+      }
+
+      s"includes the email address '${contactDetailsNoMobile.email}'" in {
+        documentWithMobile.body.getElementById("email").text shouldBe contactDetailsNoMobile.email
+      }
+
+    }
+  }
+}

--- a/test/views/ConfirmCorrespondAddressSpec.scala
+++ b/test/views/ConfirmCorrespondAddressSpec.scala
@@ -43,18 +43,23 @@ class ConfirmCorrespondAddressSpec extends ViewSpec {
     override lazy val enrolmentConnector = mockEnrolmentConnector
   }
 
-  def setupMocks(confirmCorrespondAddressModel: ConfirmCorrespondAddressModel, addressModel: Option[AddressModel] = None): Unit = {
+  def setupMocks
+  (
+    confirmCorrespondAddressModel: Option[ConfirmCorrespondAddressModel] = None,
+    backLink: Option[String] = None
+  ): Unit = {
     when(mockS4lConnector.fetchAndGetFormData[ConfirmCorrespondAddressModel](Matchers.eq(KeystoreKeys.confirmContactAddress))
-      (Matchers.any(), Matchers.any(), Matchers.any())).thenReturn(Future.successful(Some(confirmCorrespondAddressModel)))
-    when(mockS4lConnector.fetchAndGetFormData[AddressModel](Matchers.eq(KeystoreKeys.contactAddress))
-      (Matchers.any(), Matchers.any(), Matchers.any())).thenReturn(Future.successful(addressModel))
+      (Matchers.any(), Matchers.any(), Matchers.any())).thenReturn(Future.successful(confirmCorrespondAddressModel))
+    when(mockS4lConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkConfirmCorrespondence))(Matchers.any(), Matchers.any(),Matchers.any()))
+      .thenReturn(Future.successful(backLink))
   }
 
   "The Confirm Correspondence Address page" should {
 
-    "Verify that the Confirm Correspondence Address page contains the correct elements when a valid ConfirmCorrespondAddressModel is passed" in new Setup {
+    "Verify that the Confirm Correspondence Address page contains the correct elements when a valid ConfirmCorrespondAddressModel is passed" +
+      "and there is no data already stored so it uses the ETMP address" in new Setup {
       val document: Document = {
-        setupMocks(confirmCorrespondAddressModel,Some(addressModel))
+        setupMocks(None,Some("backLink"))
         val result = TestController.show.apply(authorisedFakeRequest.withFormUrlEncodedBody(
           "contactAddressUse" -> Constants.StandardRadioButtonYesValue
         ))
@@ -63,35 +68,7 @@ class ConfirmCorrespondAddressSpec extends ViewSpec {
       document.title() shouldBe Messages("page.contactInformation.ConfirmCorrespondAddress.title")
       document.getElementById("main-heading").text() shouldBe Messages("page.contactInformation.ConfirmCorrespondAddress.heading")
       document.getElementById("next").text() shouldBe Messages("common.button.continue")
-      document.body.getElementById("back-link").attr("href") shouldEqual routes.ContactDetailsController.show().url
-      document.body.getElementById("progress-section").text shouldBe Messages("common.section.progress.company.details.four")
-      document.body.getElementById("contactAddressUse-yesLabel").text shouldBe  Messages("common.radioYesLabel")
-      document.body.getElementById("contactAddressUse-noLabel").text shouldBe  Messages("common.radioNoLabel")
-      document.body.select("#contactAddressUse-yes").size() shouldBe 1
-      document.body.select("#contactAddressUse-no").size() shouldBe 1
-      document.body.getElementById("storedAddressDiv")
-      document.body.getElementById("get-help-action").text shouldBe Messages("common.error.help.text")
-      document.body.getElementById("line1-display").text shouldBe addressModel.addressline1
-      document.body.getElementById("line2-display").text shouldBe addressModel.addressline2
-      document.body.getElementById("line3-display").text shouldBe addressModel.addressline3.getOrElse("")
-      document.body.getElementById("line4-display").text shouldBe addressModel.addressline4.getOrElse("")
-      document.body.getElementById("postcode-display").text shouldBe addressModel.postcode.getOrElse("")
-      document.body.getElementById("country-display").text shouldBe utils.CountriesHelper.getSelectedCountry(addressModel.countryCode)
-      }
-
-    "Verify that the Confirm Correspondence Address page contains the correct elements when a valid" +
-      "ConfirmCorrespondAddressModel is passed but no address model is returned so the ETMP address is used" in new Setup {
-      val document: Document = {
-        setupMocks(confirmCorrespondAddressModel)
-        val result = TestController.show.apply(authorisedFakeRequest.withFormUrlEncodedBody(
-          "contactAddressUse" -> Constants.StandardRadioButtonYesValue
-        ))
-        Jsoup.parse(contentAsString(result))
-      }
-      document.title() shouldBe Messages("page.contactInformation.ConfirmCorrespondAddress.title")
-      document.getElementById("main-heading").text() shouldBe Messages("page.contactInformation.ConfirmCorrespondAddress.heading")
-      document.getElementById("next").text() shouldBe Messages("common.button.continue")
-      document.body.getElementById("back-link").attr("href") shouldEqual routes.ContactDetailsController.show().url
+      document.body.getElementById("back-link").attr("href") shouldEqual "backLink"
       document.body.getElementById("progress-section").text shouldBe Messages("common.section.progress.company.details.four")
       document.body.getElementById("contactAddressUse-yesLabel").text shouldBe  Messages("common.radioYesLabel")
       document.body.getElementById("contactAddressUse-noLabel").text shouldBe  Messages("common.radioNoLabel")
@@ -105,12 +82,40 @@ class ConfirmCorrespondAddressSpec extends ViewSpec {
       document.body.getElementById("line4-display").text shouldBe addressFromEtmp.addressline4.getOrElse("")
       document.body.getElementById("postcode-display").text shouldBe addressFromEtmp.postcode.getOrElse("")
       document.body.getElementById("country-display").text shouldBe utils.CountriesHelper.getSelectedCountry(addressFromEtmp.countryCode)
+      }
+
+    "Verify that the Confirm Correspondence Address page contains the correct elements when a valid" +
+      "and there is data stored for the confirmCorrespondenceAddress" in new Setup {
+      val document: Document = {
+        setupMocks(Some(confirmCorrespondAddressModel),Some("backLink"))
+        val result = TestController.show.apply(authorisedFakeRequest.withFormUrlEncodedBody(
+          "contactAddressUse" -> Constants.StandardRadioButtonYesValue
+        ))
+        Jsoup.parse(contentAsString(result))
+      }
+      document.title() shouldBe Messages("page.contactInformation.ConfirmCorrespondAddress.title")
+      document.getElementById("main-heading").text() shouldBe Messages("page.contactInformation.ConfirmCorrespondAddress.heading")
+      document.getElementById("next").text() shouldBe Messages("common.button.continue")
+      document.body.getElementById("back-link").attr("href") shouldEqual "backLink"
+      document.body.getElementById("progress-section").text shouldBe Messages("common.section.progress.company.details.four")
+      document.body.getElementById("contactAddressUse-yesLabel").text shouldBe  Messages("common.radioYesLabel")
+      document.body.getElementById("contactAddressUse-noLabel").text shouldBe  Messages("common.radioNoLabel")
+      document.body.select("#contactAddressUse-yes").size() shouldBe 1
+      document.body.select("#contactAddressUse-no").size() shouldBe 1
+      document.body.getElementById("storedAddressDiv")
+      document.body.getElementById("get-help-action").text shouldBe Messages("common.error.help.text")
+      document.body.getElementById("line1-display").text shouldBe confirmCorrespondAddressModel.address.addressline1
+      document.body.getElementById("line2-display").text shouldBe confirmCorrespondAddressModel.address.addressline2
+      document.body.getElementById("line3-display").text shouldBe confirmCorrespondAddressModel.address.addressline3.getOrElse("")
+      document.body.getElementById("line4-display").text shouldBe confirmCorrespondAddressModel.address.addressline4.getOrElse("")
+      document.body.getElementById("postcode-display").text shouldBe confirmCorrespondAddressModel.address.postcode.getOrElse("")
+      document.body.getElementById("country-display").text shouldBe utils.CountriesHelper.getSelectedCountry(confirmCorrespondAddressModel.address.countryCode)
     }
 
     "Verify that the Confirm Correspondence Address page contains the correct elements " +
       "when an invalid ConfirmCorrespondAddressModel is passed" in new Setup {
       val document: Document = {
-        setupMocks(confirmCorrespondAddressModel)
+        setupMocks(Some(confirmCorrespondAddressModel),Some("backLink"))
         val result = TestController.submit.apply(authorisedFakeRequest.withFormUrlEncodedBody(
           "contactAddressUse" -> "",
           "address.addressline1" -> "LineX 1 Posted",
@@ -125,7 +130,7 @@ class ConfirmCorrespondAddressSpec extends ViewSpec {
       document.title() shouldBe Messages("page.contactInformation.ConfirmCorrespondAddress.title")
       document.getElementById("main-heading").text() shouldBe Messages("page.contactInformation.ConfirmCorrespondAddress.heading")
       document.getElementById("next").text() shouldBe Messages("common.button.continue")
-      document.body.getElementById("back-link").attr("href") shouldEqual routes.ContactDetailsController.show().url
+      document.body.getElementById("back-link").attr("href") shouldEqual "backLink"
       document.body.getElementById("progress-section").text shouldBe  Messages("common.section.progress.company.details.four")
       document.body.getElementById("contactAddressUse-yesLabel").text shouldBe  Messages("common.radioYesLabel")
       document.body.getElementById("contactAddressUse-noLabel").text shouldBe  Messages("common.radioNoLabel")

--- a/test/views/ContactDetailsSpec.scala
+++ b/test/views/ContactDetailsSpec.scala
@@ -59,7 +59,7 @@ class ContactDetailsSpec extends ViewSpec {
       document.getElementById("label-mobileNumber").text() shouldBe Messages("page.contactInformation.contactDetails.mobileNumber.label")
       document.getElementById("label-email").text() shouldBe Messages("page.contactInformation.contactDetails.email.label")
       document.getElementById("next").text() shouldBe Messages("common.button.continue")
-      document.body.getElementById("back-link").attr("href") shouldEqual routes.InvestmentGrowController.show().url
+      document.body.getElementById("back-link").attr("href") shouldEqual routes.ConfirmContactDetailsController.show().url
       document.body.getElementById("progress-section").text shouldBe  Messages("common.section.progress.company.details.four")
     }
 
@@ -77,7 +77,7 @@ class ContactDetailsSpec extends ViewSpec {
       document.getElementById("label-mobileNumber").text() shouldBe Messages("page.contactInformation.contactDetails.mobileNumber.label")
       document.getElementById("label-email").text() contains Messages("page.contactInformation.contactDetails.email.label")
       document.getElementById("next").text() shouldBe Messages("common.button.continue")
-      document.body.getElementById("back-link").attr("href") shouldEqual routes.InvestmentGrowController.show().url
+      document.body.getElementById("back-link").attr("href") shouldEqual routes.ConfirmContactDetailsController.show().url
       document.body.getElementById("progress-section").text shouldBe  Messages("common.section.progress.company.details.four")
       document.getElementById("error-summary-display").hasClass("error-summary--show")
     }


### PR DESCRIPTION
Some other changes have been included on this branch following discussions with Mark Keeling:

- The correspondence address is no longer overwritten; it should retain the ETMP value on the confirm page and use the new one from the manual entry screen in the background. To solve this, I have introduced a new S4L key for manualCorrespondenceAddress, this persists the value on the manual entry screen.
- The new confirm contact details screen follows this same logic.
- The back buttons will always return to the previous page in the logical flow, so if they click yes and then manual enter and then continue, the back button on the next page will take them back to the manual entry page - as per the GDS standards confirmed by Mark

**Note**
- Another fix has been included to hide the options by correcting the javascript on the previousSchemes page.
- Also, no longer clears the values when you select other options. This is handled by the backend.
 