### PR TITLE
fix broken feedback. Add ALL flow predicate

### DIFF
--- a/app/auth/Flow.scala
+++ b/app/auth/Flow.scala
@@ -21,3 +21,4 @@ case object EIS extends Flow
 case object SEIS extends Flow
 case object VCT extends Flow
 case object SITR extends Flow
+case object ALLFLOWS extends Flow

--- a/app/controllers/SignOutController.scala
+++ b/app/controllers/SignOutController.scala
@@ -16,7 +16,7 @@
 
 package controllers
 
-import auth.AuthorisedAndEnrolledForTAVC
+import auth.{ALLFLOWS, AuthorisedAndEnrolledForTAVC}
 import config.{FrontendAppConfig, FrontendAuthConnector}
 import connectors.{EnrolmentConnector, S4LConnector}
 import play.api.mvc.{Action, AnyContent}
@@ -36,7 +36,7 @@ object SignOutController extends SignOutController {
 
 trait SignOutController extends FrontendController with AuthorisedAndEnrolledForTAVC {
 
-  override val acceptedFlows = Seq()
+  override val acceptedFlows = Seq(Seq(ALLFLOWS))
 
   def signout(): Action[AnyContent] = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     Future.successful(Redirect(s"${applicationConfig.ggSignOutUrl}?continue=${applicationConfig.signOutPageUrl}"))

--- a/app/controllers/feedback/FeedbackController.scala
+++ b/app/controllers/feedback/FeedbackController.scala
@@ -18,17 +18,17 @@ package controllers.feedback
 
 import java.net.URLEncoder
 
-import auth.AuthorisedAndEnrolledForTAVC
+import auth.{ALLFLOWS, AuthorisedAndEnrolledForTAVC}
 import play.api.Logger
 import play.api.http.{Status => HttpStatus}
 import play.api.mvc.{Action, AnyContent, Request, RequestHeader}
 import play.twirl.api.Html
-import config.{AppConfig, FrontendAppConfig, FrontendAuthConnector, WSHttp}
+import config.{FrontendAppConfig, FrontendAuthConnector, WSHttp}
 import config.FrontendGlobal.internalServerErrorTemplate
 import connectors.{EnrolmentConnector, S4LConnector}
 import views.html.feedback.feedback_thankyou
 import uk.gov.hmrc.play.frontend.auth.connectors.AuthConnector
-import uk.gov.hmrc.play.frontend.controller.{FrontendController, UnauthorisedAction}
+import uk.gov.hmrc.play.frontend.controller.FrontendController
 import uk.gov.hmrc.play.frontend.filters.SessionCookieCryptoFilter
 import uk.gov.hmrc.play.http.{HeaderCarrier, HttpGet, HttpPost, _}
 import uk.gov.hmrc.play.partials._
@@ -64,7 +64,7 @@ object FeedbackController extends FeedbackController with PartialRetriever {
 
 trait FeedbackController extends FrontendController with AuthorisedAndEnrolledForTAVC {
 
-  override val acceptedFlows = Seq()
+  override val acceptedFlows = Seq(Seq(ALLFLOWS))
 
   implicit val formPartialRetriever: FormPartialRetriever
   implicit val cachedStaticHtmlPartialRetriever: CachedStaticHtmlPartialRetriever

--- a/app/views/eis/checkAndSubmit/Acknowledgement.scala.html
+++ b/app/views/eis/checkAndSubmit/Acknowledgement.scala.html
@@ -2,6 +2,7 @@
 @import uk.gov.hmrc.play.views.html.helpers.{form}
 @import helpers.backButton
 @import config.FrontendAppConfig
+@import controllers.feedback.routes
 
 @(submissionResponseModel: SubmissionResponse)(implicit request: Request[_], messages: Messages)
 
@@ -72,11 +73,10 @@
             <h2 id="waiting-time" class="heading-medium">@Messages("page.checkAndSubmit.acknowledgement.waitingTime.heading")</h2>
                 <p id="course-of-action">@Messages("page.checkAndSubmit.acknowledgement.courseOfAction")</p>
         </div>
+        <div class="form-group">
+            <a id="submit" class="button" href="@controllers.feedback.routes.FeedbackController.show().url">@Messages("page.checkAndSubmit.acknowledgement.button.confirm")</a>
+        </div>
     </div>
 </div>
-
-@form(action = controllers.eis.routes.AcknowledgementController.submit()) {
-    <button class="button" type="submit" id="submit">@Messages("page.checkAndSubmit.acknowledgement.button.confirm")</button>
-}
 
 }

--- a/app/views/seis/checkAndSubmit/Acknowledgement.scala.html
+++ b/app/views/seis/checkAndSubmit/Acknowledgement.scala.html
@@ -2,6 +2,7 @@
 @import uk.gov.hmrc.play.views.html.helpers.{form}
 @import helpers.backButton
 @import config.FrontendAppConfig
+@import controllers.feedback.routes
 
 @(submissionResponseModel: SubmissionResponse)(implicit request: Request[_], messages: Messages)
 
@@ -72,11 +73,10 @@
             <h2 id="waiting-time" class="heading-medium">@Messages("page.seis.checkAndSubmit.acknowledgement.waitingTime.heading")</h2>
             <p id="course-of-action">@Messages("page.seis.checkAndSubmit.acknowledgement.courseOfAction")</p>
         </div>
+        <div class="form-group">
+            <a id="submit" class="button" href="@controllers.feedback.routes.FeedbackController.show().url">@Messages("page.seis.checkAndSubmit.acknowledgement.button.confirm")</a>
+        </div>
     </div>
 </div>
-
-@form(action = controllers.seis.routes.AcknowledgementController.submit()) {
-<button class="button" type="submit" id="submit">@Messages("page.seis.checkAndSubmit.acknowledgement.button.confirm")</button>
-}
 
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -69,8 +69,8 @@ Dev {
   }
 
   features {
-    UploadEnabled = false
-    seisFlowEnabled = false
+    UploadEnabled = true
+    seisFlowEnabled = true
   }
 }
 
@@ -114,8 +114,8 @@ Test {
   }
 
   features {
-    UploadEnabled = false
-    seisFlowEnabled = false
+    UploadEnabled = true
+    seisFlowEnabled = true
   }
 }
 

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,0 +1,1 @@
+type: service


### PR DESCRIPTION
The issue with the feedback was that when you post back to the Acknowledgement controller and then redirect to the feedback controller, the initial post to the Acknowledgement controller performs the switching check against that acknowledgement controller (which has acceptedFlows = Seq(Seq(EIS),Seq(VCT),Seq(EIS,VCT)).

Because session cache is cleared on submit it cannot perform the scheme types check.
I resolved this by not posting back from the acknowledgement page to the feedback paste but using a hyper-link styled button instead (GET), It;s all good now.

I added an ALLFLOWS sequence which isn't strictly necessary now but it seems quite useful so I left it.
 